### PR TITLE
refactor(Permissions): rename types, fix explicit/implicit issue

### DIFF
--- a/lib/structs/permissions.ex
+++ b/lib/structs/permissions.ex
@@ -313,6 +313,38 @@ defmodule Crux.Structs.Permissions do
     (have &&& want) == want
   end
 
+  @doc ~S"""
+    Similar to `has/2` but returns a `Crux.Structs.Permissions` of the missing permissions.
+
+    ## Examples
+      ```
+    iex> Crux.Structs.Permissions.missing([:send_messages, :view_channel], [:send_messages, :view_channel, :embed_links])
+    %Crux.Structs.Permissions{bitfield: 0x4000}
+
+    # Administrator won't implicilty grant other permissions
+    iex> Crux.Structs.Permissions.missing([:administrator], [:send_messages])
+    %Crux.Structs.Permissions{bitfield: 0x800}
+
+    # Everything set
+    iex> Crux.Structs.Permissions.missing([:kick_members, :ban_members, :view_audit_log], [:kick_members, :ban_members])
+    %Crux.Structs.Permissions{bitfield: 0}
+
+    # No permissions
+    iex> Crux.Structs.Permissions.missing([:send_messages, :view_channel], [])
+    %Crux.Structs.Permissions{bitfield: 0}
+
+  """
+  @spec missing(resolvable(), resolvable()) :: t()
+  Util.since("0.2.0")
+
+  def missing(have, want) do
+    have = resolve(have)
+    want = resolve(want)
+
+    (want &&& ~~~have)
+    |> new()
+  end
+
   @doc """
     Resolves permissions for a user in a guild, optionally including channel permission overwrites.
 

--- a/lib/structs/permissions.ex
+++ b/lib/structs/permissions.ex
@@ -206,7 +206,7 @@ defmodule Crux.Structs.Permissions do
   def to_map(permissions) do
     permissions = resolve(permissions)
 
-    Enum.into(@names, %{}, &{&1, has(permissions, &1)})
+    Map.new(@names, &{&1, has(permissions, &1)})
   end
 
   @doc ~S"""

--- a/test/structs/permissions_test.exs
+++ b/test/structs/permissions_test.exs
@@ -1,19 +1,176 @@
 defmodule Crux.Structs.PermissionsTest do
   use ExUnit.Case, async: true
-  doctest Crux.Structs.Permissions
+
+  alias Crux.Structs.{Channel, Guild, Member, Overwrite, Permissions, Role}
+
+  doctest Permissions
 
   test "to_map" do
     permissions = [:view_channel, :send_messages, :kick_members, :embed_links]
 
-    Crux.Structs.Permissions.to_map(permissions)
+    Permissions.to_map(permissions)
     |> Enum.each(fn {name, value} ->
       assert {name, name in permissions} === {name, value}
     end)
   end
 
+  test "to_map administrator does not override" do
+    explicit_count =
+      :administrator
+      |> Permissions.to_map()
+      |> Map.values()
+      |> Enum.count(& &1)
+
+    assert explicit_count === 1
+  end
+
   test "to_list" do
     permissions = [:view_channel, :send_messages, :kick_members, :embed_links]
 
-    assert permissions === Crux.Structs.Permissions.to_list(permissions)
+    assert permissions === Permissions.to_list(permissions)
+  end
+
+  test "to_list administrator does not override" do
+    explicit_count =
+      :administrator
+      |> Permissions.to_list()
+      |> Enum.count()
+
+    assert explicit_count === 1
+  end
+
+  test "implicit/2 owner overrides" do
+    member = %Member{user: 218_348_062_828_003_328}
+    guild = %Guild{owner_id: 218_348_062_828_003_328}
+
+    %Permissions{bitfield: bitfield} = Permissions.implicit(member, guild)
+
+    assert bitfield === Permissions.all()
+  end
+
+  test "implicit/2 administrator overrides" do
+    [member, guild, _] = test_data()
+
+    %Permissions{bitfield: bitfield} = Permissions.implicit(member, guild)
+
+    assert bitfield === Permissions.all()
+  end
+
+  test "implicit/3 administrator override" do
+    [member, guild, channel] = test_data()
+
+    %Permissions{bitfield: bitfield} = Permissions.implicit(member, guild, channel)
+
+    assert bitfield === Permissions.all()
+  end
+
+  test "implicit/3 administrator in overwrite does not override" do
+    [member, guild, channel] =
+      test_data(no_admin: true, allow: Permissions.resolve([:administrator]), deny: 0)
+
+    %Permissions{bitfield: bitfield} = Permissions.implicit(member, guild, channel)
+
+    # not equal to Permissions.all() !
+    assert bitfield ===
+             Permissions.resolve([
+               :administrator,
+               :view_channel,
+               :send_messages,
+               :kick_members,
+               :ban_members,
+               :read_message_history
+             ])
+  end
+
+  test "explicit/2 administrator nor owner does not override" do
+    [member, guild, _] = test_data()
+    guild = Map.put(guild, :owner, member.user)
+
+    %Permissions{bitfield: bitfield} = Permissions.explicit(member, guild)
+
+    assert bitfield ===
+             Permissions.resolve([
+               :administrator,
+               :view_channel,
+               :send_messages,
+               :kick_members,
+               :ban_members,
+               :read_message_history
+             ])
+  end
+
+  test "explicit/3 administrator nor owner does not override" do
+    [member, guild, channel] = test_data(allow: Permissions.resolve([:administrator]))
+    guild = Map.put(guild, :owner, member.user)
+
+    %Permissions{bitfield: bitfield} = Permissions.explicit(member, guild, channel)
+
+    assert bitfield ===
+             Permissions.resolve([
+               :administrator,
+               :send_messages,
+               :kick_members,
+               :ban_members,
+               :read_message_history
+             ])
+  end
+
+  test "no roles does not raise" do
+    [member, guild, _] = test_data()
+
+    guild =
+      Map.update!(
+        guild,
+        :members,
+        fn members ->
+          Map.update!(members, 218_348_062_828_003_328, &Map.put(&1, :roles, MapSet.new()))
+        end
+      )
+
+    assert guild.members[218_348_062_828_003_328].roles |> MapSet.size() === 0
+
+    %Permissions{bitfield: bitfield} = Permissions.explicit(member, guild)
+
+    assert bitfield === Permissions.resolve([:view_channel, :send_messages])
+  end
+
+  defp test_data(options \\ []) do
+    member = %Member{user: 218_348_062_828_003_328}
+
+    guild = %Guild{
+      id: 243_175_181_885_898_762,
+      members: %{
+        218_348_062_828_003_328 => %Member{
+          roles: MapSet.new([251_158_405_832_638_465, 373_405_430_589_816_834])
+        }
+      },
+      roles: %{
+        # @everyone
+        243_175_181_885_898_762 => %Role{
+          permissions: Permissions.resolve([:view_channel, :send_messages])
+        },
+        251_158_405_832_638_465 => %Role{
+          permissions: Permissions.resolve([:kick_members, :ban_members])
+        },
+        373_405_430_589_816_834 => %Role{
+          permissions:
+            Permissions.resolve([
+              if(options[:no_admin], do: 0, else: :administrator),
+              :read_message_history
+            ])
+        }
+      }
+    }
+
+    channel = %Channel{
+      permission_overwrites: %{
+        243_175_181_885_898_762 => %Overwrite{
+          allow: options[:allow] || 0,
+          deny: options[:deny] || Permissions.resolve([:view_channel])
+        }
+      }
+    }
+
+    [member, guild, channel]
   end
 end


### PR DESCRIPTION
The goals of this PR are to:
- Fix the edge case of the administrator permission set in an override granting all permissions
- Fix an empty list as resolvable raising an `EmptyError`
- Add `missing/2`

This is achieved by making all functions in the module **explicit**.

`implicit/2-3` is not affected by this edge case either, since the administrator permission in the override won't be treated as a "grant-all", but just as is.
> This is not issue, since `has/2` is explicit as well.

#### Type changes:
- `permission_name/0` -> `name/0`
- [not existing] -> `resolvable/0`

#### Method changes:
- `permissions/0` -> `names/0`
- `permission_all/0` -> `all/0`
- `from/2-3` -> [not existing]
- [not existing] -> `explicit/2-3`
- [not existing] -> `implicit/2-3`
- [not existing] -> `missing/2`

