### PR TITLE
feat(presence): add client_status map

### DIFF
--- a/lib/structs/presence.ex
+++ b/lib/structs/presence.ex
@@ -19,7 +19,8 @@ defmodule Crux.Structs.Presence do
     game: nil,
     # guild_id: nil,
     status: "offline",
-    activities: []
+    activities: [],
+    client_status: %{}
   )
 
   Util.typesince("0.1.0")
@@ -30,7 +31,8 @@ defmodule Crux.Structs.Presence do
           game: map() | nil,
           # guild_id: Crux.Rest.snowflake() | nil,
           status: String.t(),
-          activities: [map()]
+          activities: [map()],
+          client_status: %{required(atom()) => atom()}
         }
 
   @doc """


### PR DESCRIPTION
This PR adds a `client_presence` key to the `Presence` struct showing on what platform the user is currently logged in and the status there.

~~This fields is not documented in [Discords Documentation](https://discordapp.com/developers/docs/topics/gateway#presence-update-presence-update-event-fields) and may not be intended to be available to bots.~~

~~Do not merge before this is clarified.~~

Edit:
There is a PR to document this: https://github.com/discordapp/discord-api-docs/pull/829

Edit2:
The PR has been merged.
