### PR TITLE
Fix broken codeblock for `Crux.Structs.Permission.missing/2`.

### DIFF
--- a/lib/structs/permissions.ex
+++ b/lib/structs/permissions.ex
@@ -317,8 +317,8 @@ defmodule Crux.Structs.Permissions do
   @doc ~S"""
     Similar to `has/2` but returns a `Crux.Structs.Permissions` of the missing permissions.
 
-    ## Examples
-      ```
+  ## Examples
+    ```elixir
     iex> Crux.Structs.Permissions.missing([:send_messages, :view_channel], [:send_messages, :view_channel, :embed_links])
     %Crux.Structs.Permissions{bitfield: 0x4000}
 
@@ -333,7 +333,7 @@ defmodule Crux.Structs.Permissions do
     # No permissions
     iex> Crux.Structs.Permissions.missing([:send_messages, :view_channel], [])
     %Crux.Structs.Permissions{bitfield: 0}
-
+    ```
   """
   @spec missing(resolvable(), resolvable()) :: t()
   Util.since("0.2.0")

--- a/lib/structs/permissions.ex
+++ b/lib/structs/permissions.ex
@@ -333,6 +333,7 @@ defmodule Crux.Structs.Permissions do
   # No permissions
   iex> Crux.Structs.Permissions.missing([:send_messages, :view_channel], [])
   %Crux.Structs.Permissions{bitfield: 0}
+
     ```
   """
   @spec missing(resolvable(), resolvable()) :: t()

--- a/lib/structs/permissions.ex
+++ b/lib/structs/permissions.ex
@@ -319,20 +319,20 @@ defmodule Crux.Structs.Permissions do
 
   ## Examples
     ```elixir
-    iex> Crux.Structs.Permissions.missing([:send_messages, :view_channel], [:send_messages, :view_channel, :embed_links])
-    %Crux.Structs.Permissions{bitfield: 0x4000}
+  iex> Crux.Structs.Permissions.missing([:send_messages, :view_channel], [:send_messages, :view_channel, :embed_links])
+  %Crux.Structs.Permissions{bitfield: 0x4000}
 
-    # Administrator won't implicilty grant other permissions
-    iex> Crux.Structs.Permissions.missing([:administrator], [:send_messages])
-    %Crux.Structs.Permissions{bitfield: 0x800}
+  # Administrator won't implicilty grant other permissions
+  iex> Crux.Structs.Permissions.missing([:administrator], [:send_messages])
+  %Crux.Structs.Permissions{bitfield: 0x800}
 
-    # Everything set
-    iex> Crux.Structs.Permissions.missing([:kick_members, :ban_members, :view_audit_log], [:kick_members, :ban_members])
-    %Crux.Structs.Permissions{bitfield: 0}
+  # Everything set
+  iex> Crux.Structs.Permissions.missing([:kick_members, :ban_members, :view_audit_log], [:kick_members, :ban_members])
+  %Crux.Structs.Permissions{bitfield: 0}
 
-    # No permissions
-    iex> Crux.Structs.Permissions.missing([:send_messages, :view_channel], [])
-    %Crux.Structs.Permissions{bitfield: 0}
+  # No permissions
+  iex> Crux.Structs.Permissions.missing([:send_messages, :view_channel], [])
+  %Crux.Structs.Permissions{bitfield: 0}
     ```
   """
   @spec missing(resolvable(), resolvable()) :: t()


### PR DESCRIPTION
Was reading the docs when I found that this codeblock was broken. Might as well fix it :)