### PR TITLE
feat(Permissions): add stream permission

### DIFF
--- a/lib/structs/permissions.ex
+++ b/lib/structs/permissions.ex
@@ -22,7 +22,7 @@ defmodule Crux.Structs.Permissions do
     add_reactions: 1 <<< 6,
     view_audit_log: 1 <<< 7,
     priority_speaker: 1 <<< 8,
-    # 9
+    stream: 1 <<< 9,
     view_channel: 1 <<< 10,
     send_messages: 1 <<< 11,
     send_tts_message: 1 <<< 12,
@@ -83,6 +83,7 @@ defmodule Crux.Structs.Permissions do
           | :add_reactions
           | :view_audit_log
           | :priority_speaker
+          | :stream
           | :view_channel
           | :send_messages
           | :send_tts_message


### PR DESCRIPTION
Adds the `stream` permissions flag to the `Structs.Permissions` struct.

This bit will most likely be required in order to use guild screenshare in a given "voice" channel.

This permission bit is not yet required to use the guild screenshare feature if the guild has it enabled.
~~There is no documentation for this yet.~~
It was added to the documentation with https://github.com/discordapp/discord-api-docs/commit/182130b4b86e1d9f8c824473f20d0156bbc48927