### PR TITLE
feat(Message): add support for new fields, add missing fields

### DIFF
--- a/.credo.exs
+++ b/.credo.exs
@@ -54,7 +54,6 @@
         {Credo.Check.Refactor.LongQuoteBlocks},
         {Credo.Check.Refactor.MapInto},
         {Credo.Check.Refactor.MatchInCondition},
-        {Credo.Check.Refactor.ModuleDependencies, max_deps: 13},
         {Credo.Check.Refactor.NegatedConditionsInUnless},
         {Credo.Check.Refactor.NegatedConditionsWithElse},
         {Credo.Check.Refactor.Nesting},

--- a/lib/structs/message.ex
+++ b/lib/structs/message.ex
@@ -15,49 +15,97 @@ defmodule Crux.Structs.Message do
   Util.modulesince("0.1.0")
 
   defstruct(
+    activity: nil,
+    application: nil,
     attachments: [],
     author: nil,
     channel_id: nil,
     content: nil,
     edited_timestamp: nil,
     embeds: [],
+    flags: 0,
     guild_id: nil,
     id: nil,
     member: nil,
+    mention_channels: [],
     mention_everyone: false,
     mention_roles: MapSet.new(),
     mentions: MapSet.new(),
+    message_reference: nil,
     nonce: nil,
-    pinned: false,
-    timestamp: nil,
-    tts: false,
-    type: 0,
+    pinned: nil,
     reactions: %{},
+    timestamp: nil,
+    tts: nil,
+    type: 0,
     webhook_id: nil
   )
+
+  Util.typesince("0.2.1")
+
+  @type message_activity :: %{
+          optional(:party_id) => String.t(),
+          type: integer()
+        }
+
+  Util.typesince("0.2.1")
+
+  @type message_application :: %{
+          id: Crux.Rest.snowflake(),
+          cover_image: String.t() | nil,
+          description: String.t(),
+          icon: String.t() | nil,
+          name: String.t()
+        }
+
+  Util.typesince("0.2.1")
+
+  @type mention_channel :: %{
+          id: Crux.Rest.snowflake(),
+          guild_id: Crux.Rest.snowflake(),
+          name: String.t(),
+          type: non_neg_integer()
+        }
+
+  @typedoc """
+  * `message_id` is `nil` for the initial message sent when a user starts following a channel.
+  * `guild_id` is only `nil` for some messages during the initial rollout of this feature.
+  """
+  Util.typesince("0.2.1")
+
+  @type message_reference :: %{
+          message_id: Crux.Rest.snowflake() | nil,
+          guild_id: Crux.Rest.snowflake() | nil,
+          channel_id: Crux.Rest.snowflake()
+        }
 
   Util.typesince("0.1.0")
 
   @type t :: %__MODULE__{
+          activity: message_activity() | nil,
+          application: message_application() | nil,
           attachments: [Attachment.t()],
-          # Might be webhook
+          # Might be a webhook user
           author: User.t(),
           channel_id: Crux.Rest.snowflake(),
           content: String.t(),
           edited_timestamp: String.t(),
           embeds: [Embed.t()],
+          flags: non_neg_integer(),
           guild_id: Crux.Rest.snowflake() | nil,
           id: Crux.Rest.snowflake(),
           member: Member.t() | nil,
+          mention_channels: [mention_channel()],
           mention_everyone: boolean(),
           mention_roles: MapSet.t(Crux.Rest.snowflake()),
           mentions: MapSet.t(Crux.Rest.snowflake()),
+          message_reference: message_reference(),
           nonce: String.t() | nil,
           pinned: boolean(),
+          reactions: %{String.t() => Reaction.t()},
           timestamp: String.t(),
           tts: boolean(),
           type: integer(),
-          reactions: %{String.t() => Reaction.t()},
           webhook_id: Crux.Rest.snowflake() | nil
         }
 
@@ -73,35 +121,56 @@ defmodule Crux.Structs.Message do
     data =
       data
       |> Util.atomify()
+      |> Map.update(:application, nil, &Map.update(&1, :id, nil, fn id -> Util.id_to_int(id) end))
       |> Map.update(:attachments, [], &Structs.create(&1, Attachment))
       |> Map.update!(:author, &Structs.create(&1, User))
       |> Map.update!(:channel_id, &Util.id_to_int/1)
       |> Map.update(:embeds, [], &Structs.create(&1, Embed))
       |> Map.update(:guild_id, nil, &Util.id_to_int/1)
       |> Map.update!(:id, &Util.id_to_int/1)
-
-    message =
-      data
-      |> Map.update(:member, nil, create_member(data))
+      |> Map.update(:mention_channels, [], &create_mention_channel/1)
       |> Map.update(
         :mention_roles,
         %MapSet{},
         &MapSet.new(&1, fn role_id -> Util.id_to_int(role_id) end)
       )
       |> Map.update(:mentions, %MapSet{}, &MapSet.new(&1, Util.map_to_id()))
+      |> Map.update(:message_reference, nil, &create_message_reference/1)
       |> Map.update(
         :reactions,
         %{},
         &Map.new(&1, fn reaction ->
           reaction = Structs.create(reaction, Reaction)
-          id = reaction.emoji.id || reaction.emoji.name
+          key = reaction.emoji.id || reaction.emoji.name
 
-          {id, reaction}
+          {key, reaction}
         end)
       )
       |> Map.update(:webhook_id, nil, &Util.id_to_int/1)
 
+    message =
+      data
+      |> Map.update(:member, nil, create_member(data))
+
     struct(__MODULE__, message)
+  end
+
+  defp create_mention_channel(mention_channels)
+       when is_list(mention_channels) do
+    Enum.map(mention_channels, &create_mention_channel/1)
+  end
+
+  defp create_mention_channel(%{} = mention_channel) do
+    mention_channel
+    |> Map.update!(:id, &Util.id_to_int/1)
+    |> Map.update!(:guild_id, &Util.id_to_int/1)
+  end
+
+  defp create_message_reference(%{} = message_reference) do
+    message_reference
+    |> Map.update(:message_id, nil, &Util.id_to_int/1)
+    |> Map.update(:channel_id, nil, &Util.id_to_int/1)
+    |> Map.update(:guild_id, nil, &Util.id_to_int/1)
   end
 
   defp create_member(data) do

--- a/lib/structs/message.ex
+++ b/lib/structs/message.ex
@@ -148,9 +148,7 @@ defmodule Crux.Structs.Message do
       )
       |> Map.update(:webhook_id, nil, &Util.id_to_int/1)
 
-    message =
-      data
-      |> Map.update(:member, nil, create_member(data))
+    message = Map.update(data, :member, nil, create_member(data))
 
     struct(__MODULE__, message)
   end

--- a/test/structs/message_test.exs
+++ b/test/structs/message_test.exs
@@ -6,6 +6,10 @@ defmodule Crux.Structs.MessageTest do
   test "create" do
     message =
       %{
+        "activity" => %{
+          "type" => 0,
+          "party_id" => "interesting_id"
+        },
         "attachments" => [],
         "author" => %{
           "avatar" => "646a356e237350bf8b8dfde15667dfc4",
@@ -25,6 +29,14 @@ defmodule Crux.Structs.MessageTest do
         "edited_timestamp" => nil,
         "embeds" => [],
         "id" => "440947000364630017",
+        "mention_channels" => [
+          %{
+            "id" => "278325129692446722",
+            "guild_id" => "278325129692446720",
+            "name" => "big-news",
+            "type" => 5
+          }
+        ],
         "mention_everyone" => false,
         "mention_roles" => [],
         "mentions" => [
@@ -45,11 +57,21 @@ defmodule Crux.Structs.MessageTest do
         "pinned" => false,
         "timestamp" => "2018-05-01T18:45:57.286000+00:00",
         "tts" => false,
-        "type" => 0
+        "type" => 0,
+        "flags" => 2,
+        "message_reference" => %{
+          "channel_id" => "278325129692446722",
+          "guild_id" => "278325129692446720",
+          "message_id" => "306588351130107906"
+        }
       }
       |> Crux.Structs.create(Crux.Structs.Message)
 
     assert message == %Crux.Structs.Message{
+             activity: %{
+               type: 0,
+               party_id: "interesting_id"
+             },
              attachments: [],
              author: %Crux.Structs.User{
                username: "space",
@@ -75,13 +97,27 @@ defmodule Crux.Structs.MessageTest do
              edited_timestamp: nil,
              embeds: [],
              id: 440_947_000_364_630_017,
+             mention_channels: [
+               %{
+                 id: 278_325_129_692_446_722,
+                 guild_id: 278_325_129_692_446_720,
+                 name: "big-news",
+                 type: 5
+               }
+             ],
              mention_everyone: false,
              mention_roles: %MapSet{},
              mentions: MapSet.new([218_348_062_828_003_328]),
              pinned: false,
              timestamp: "2018-05-01T18:45:57.286000+00:00",
              tts: false,
-             type: 0
+             type: 0,
+             flags: 2,
+             message_reference: %{
+               channel_id: 278_325_129_692_446_722,
+               guild_id: 278_325_129_692_446_720,
+               message_id: 306_588_351_130_107_906
+             }
            }
   end
 


### PR DESCRIPTION
This PR adds support for the new message fields:
* `:mention_channels`
* `:message_reference`
* `:flags`

As well as (hopefully) all other missing fields:
* `:activity`
* `:application`

Closes #5 as the property is included here.

See the documenting PRs:
* https://github.com/discordapp/discord-api-docs/pull/1051
* https://github.com/discordapp/discord-api-docs/pull/1071