### PR TITLE
feat(Guild): add missing fields

### DIFF
--- a/test/structs/guild_test.exs
+++ b/test/structs/guild_test.exs
@@ -1,0 +1,12 @@
+defmodule Crux.Structs.GuildTest do
+  use ExUnit.Case, async: true
+  doctest Crux.Structs.Guild
+
+  test "to_string returns name" do
+    stringified =
+      %Crux.Structs.Guild{name: "a cool name"}
+      |> to_string()
+
+    assert stringified == "a cool name"
+  end
+end


### PR DESCRIPTION
This PR adds support for the "new" guild field:
* `:preferred_locale`

As well as (hopefully) all other missing fields:
* `:premium_subscription_count`
* `:premium_tier`
* `:system_channel_flags`
* `:system_channel_id`

Relevant PR for the `preferred_locale` field: https://github.com/discordapp/discord-api-docs/pull/1074