### PR TITLE
docs(Webhook): token is optional

### DIFF
--- a/lib/structs/webhook.ex
+++ b/lib/structs/webhook.ex
@@ -31,7 +31,7 @@ defmodule Crux.Structs.Webhook do
           channel_id: Crux.Rest.snowflake(),
           guild_id: Crux.Rest.snowflake() | nil,
           name: String.t() | nil,
-          token: String.t(),
+          token: String.t() | nil,
           user: Crux.Rest.snowflake() | nil
         }
 


### PR DESCRIPTION
Webhooks are missing their `:token` if they are:
- Obtained via audit logs
- Used to cross-post messages

Relevant PR: https://github.com/discordapp/discord-api-docs/pull/1033
And its closing commit: https://github.com/discordapp/discord-api-docs/commit/b36723bcbcd708bc17fae935cc2e5ec396fa36bb