### PR TITLE
feat(Permissions): add new :view_guild_insights permission

### DIFF
--- a/lib/structs/permissions.ex
+++ b/lib/structs/permissions.ex
@@ -93,6 +93,7 @@ defmodule Crux.Structs.Permissions do
           | :read_message_histroy
           | :mention_everyone
           | :use_external_emojis
+          | :view_server_analytics
           | :connect
           | :speak
           | :mute_members

--- a/lib/structs/permissions.ex
+++ b/lib/structs/permissions.ex
@@ -32,7 +32,7 @@ defmodule Crux.Structs.Permissions do
     read_message_history: 1 <<< 16,
     mention_everyone: 1 <<< 17,
     use_external_emojis: 1 <<< 18,
-    # 19
+    view_server_analytics: 1 <<< 19,
     connect: 1 <<< 20,
     speak: 1 <<< 21,
     mute_members: 1 <<< 22,

--- a/lib/structs/permissions.ex
+++ b/lib/structs/permissions.ex
@@ -32,7 +32,7 @@ defmodule Crux.Structs.Permissions do
     read_message_history: 1 <<< 16,
     mention_everyone: 1 <<< 17,
     use_external_emojis: 1 <<< 18,
-    view_server_analytics: 1 <<< 19,
+    view_guild_insights: 1 <<< 19,
     connect: 1 <<< 20,
     speak: 1 <<< 21,
     mute_members: 1 <<< 22,
@@ -93,7 +93,7 @@ defmodule Crux.Structs.Permissions do
           | :read_message_histroy
           | :mention_everyone
           | :use_external_emojis
-          | :view_server_analytics
+          | :view_guild_insights
           | :connect
           | :speak
           | :mute_members


### PR DESCRIPTION
This PR adds support for the newly available permission `VIEW_GUILD_INSIGHTS` which allows users to access said tab in the server settings.

There currently is a PR open documenting this: https://github.com/discordapp/discord-api-docs/pull/1421