### PR TITLE
feat: add resolvables

### DIFF
--- a/lib/structs.ex
+++ b/lib/structs.ex
@@ -3,8 +3,9 @@ defmodule Crux.Structs do
     Provides a unified function to create one or a list of structs, invoking their `c:create/1` function if available.
   """
 
-  alias Crux.Structs.Util
+  alias Crux.Structs.{Snowflake, Util}
   require Util
+  require Snowflake
 
   Util.modulesince("0.1.0")
 
@@ -12,7 +13,13 @@ defmodule Crux.Structs do
     Can be implemented by structs to transform the inital data.
   """
   @callback create(data :: map()) :: struct()
-  @optional_callbacks create: 1
+
+  @doc """
+    Can be implemented by structs to provide a mechanism to resolve their id.
+  """
+  @callback resolve_id(data :: map() | Snowflake.t()) :: Snowflake.t() | nil
+
+  @optional_callbacks create: 1, resolve_id: 1
 
   @doc ~S"""
     Creates a struct or a list of structs invoking their `c:create/1` function if available.
@@ -20,54 +27,54 @@ defmodule Crux.Structs do
   ## Examples
 
     ```elixir
-  # A single member
-  iex> %{
-  ...>   "nick" => "nick",
-  ...>   "user" => %{"username" => "space", "discriminator" => "0001", "id" => "218348062828003328", "avatar" => "646a356e237350bf8b8dfde15667dfc4"},
-  ...>   "roles" => ["251158405832638465", "373405430589816834"],
-  ...>   "mute" => false,
-  ...>   "deaf" => false,
-  ...>   "joined_at" => "2016-11-02T00:51:21.342000+00:00"
-  ...> }
-  ...> |> Crux.Structs.create(Crux.Structs.Member)
-  %Crux.Structs.Member{
-    nick: "nick",
-    user: 218348062828003328,
-    roles: MapSet.new([251158405832638465, 373405430589816834]),
-    mute: false,
-    deaf: false,
-    joined_at: "2016-11-02T00:51:21.342000+00:00",
-    guild_id: nil
-  }
+    # A single member
+    iex> %{
+    ...>   "nick" => "nick",
+    ...>   "user" => %{"username" => "space", "discriminator" => "0001", "id" => "218348062828003328", "avatar" => "646a356e237350bf8b8dfde15667dfc4"},
+    ...>   "roles" => ["251158405832638465", "373405430589816834"],
+    ...>   "mute" => false,
+    ...>   "deaf" => false,
+    ...>   "joined_at" => "2016-11-02T00:51:21.342000+00:00"
+    ...> }
+    ...> |> Crux.Structs.create(Crux.Structs.Member)
+    %Crux.Structs.Member{
+      nick: "nick",
+      user: 218348062828003328,
+      roles: MapSet.new([251158405832638465, 373405430589816834]),
+      mute: false,
+      deaf: false,
+      joined_at: "2016-11-02T00:51:21.342000+00:00",
+      guild_id: nil
+    }
 
-  # A single user
-  iex> %{"username" => "space", "discriminator" => "0001", "id" => "218348062828003328", "avatar" => "46a356e237350bf8b8dfde15667dfc4"}
-  ...> |> Crux.Structs.create(Crux.Structs.User)
-  %Crux.Structs.User{username: "space", discriminator: "0001", id: 218348062828003328, avatar: "46a356e237350bf8b8dfde15667dfc4"}
+    # A single user
+    iex> %{"username" => "space", "discriminator" => "0001", "id" => "218348062828003328", "avatar" => "46a356e237350bf8b8dfde15667dfc4"}
+    ...> |> Crux.Structs.create(Crux.Structs.User)
+    %Crux.Structs.User{username: "space", discriminator: "0001", id: 218348062828003328, avatar: "46a356e237350bf8b8dfde15667dfc4"}
 
-  # Multiple users
-  iex> [
-  ...>   %{"username" => "space", "discriminator" => "0001", "id" => "218348062828003328", "avatar" => "46a356e237350bf8b8dfde15667dfc4"},
-  ...>   %{"username" => "Drahcirius", "discriminator" => "1336", "id" => "130175406673231873", "avatar" => "c896aebec82c90f590b08cfebcdc4e3b"}
-  ...> ]
-  ...> |> Crux.Structs.create(Crux.Structs.User)
-  [
-    %Crux.Structs.User{username: "space", discriminator: "0001", id: 218348062828003328, avatar: "46a356e237350bf8b8dfde15667dfc4"},
-    %Crux.Structs.User{username: "Drahcirius", discriminator: "1336", id: 130175406673231873, avatar: "c896aebec82c90f590b08cfebcdc4e3b"}
-  ]
+    # Multiple users
+    iex> [
+    ...>   %{"username" => "space", "discriminator" => "0001", "id" => "218348062828003328", "avatar" => "46a356e237350bf8b8dfde15667dfc4"},
+    ...>   %{"username" => "Drahcirius", "discriminator" => "1336", "id" => "130175406673231873", "avatar" => "c896aebec82c90f590b08cfebcdc4e3b"}
+    ...> ]
+    ...> |> Crux.Structs.create(Crux.Structs.User)
+    [
+      %Crux.Structs.User{username: "space", discriminator: "0001", id: 218348062828003328, avatar: "46a356e237350bf8b8dfde15667dfc4"},
+      %Crux.Structs.User{username: "Drahcirius", discriminator: "1336", id: 130175406673231873, avatar: "c896aebec82c90f590b08cfebcdc4e3b"}
+    ]
 
-  # Does not alter already structs
-  iex> Crux.Structs.create(
-  ...>   %Crux.Structs.User{username: "space", discriminator: "0001", id: 218348062828003328, avatar: "46a356e237350bf8b8dfde15667dfc4"},
-  ...>   Crux.Structs.User
-  ...> )
-  %Crux.Structs.User{username: "space", discriminator: "0001", id: 218348062828003328, avatar: "46a356e237350bf8b8dfde15667dfc4"}
+    # Does not alter already structs
+    iex> Crux.Structs.create(
+    ...>   %Crux.Structs.User{username: "space", discriminator: "0001", id: 218348062828003328, avatar: "46a356e237350bf8b8dfde15667dfc4"},
+    ...>   Crux.Structs.User
+    ...> )
+    %Crux.Structs.User{username: "space", discriminator: "0001", id: 218348062828003328, avatar: "46a356e237350bf8b8dfde15667dfc4"}
 
-  # Fallback
-  iex> Crux.Structs.create(nil, nil)
-  nil
+    # Fallback
+    iex> Crux.Structs.create(nil, nil)
+    nil
 
-  ```
+    ```
   """
   @spec create(data :: map(), target :: module()) :: struct()
   @spec create(data :: list(), target :: module()) :: list(struct())
@@ -91,4 +98,80 @@ defmodule Crux.Structs do
       struct(target, data)
     end
   end
+
+  @doc """
+    Resolves the id of a struct invoking their `c:resolve_id/1` function if available.
+
+    ```elixir
+    # Struct of the concrete type
+    iex> %Crux.Structs.Webhook{id: 618733351624507394}
+    ...> |> Crux.Structs.resolve_id(Crux.Structs.Webhook)
+    618733351624507394
+
+    # Already snowflake
+    iex> 222089067028807682
+    ...> |> Crux.Structs.resolve_id(Crux.Structs.Role)
+    222089067028807682
+
+    # Snowflake string
+    iex> "222079895583457280"
+    ...> |> Crux.Structs.resolve_id(Crux.Structs.Channel)
+    222079895583457280
+
+    # nil
+    iex> nil
+    ...> |> Crux.Structs.resolve_id(Crux.Structs.Guild)
+    nil
+
+    # Inexact type that is a resolvable
+    iex> %Crux.Structs.Member{user: 218348062828003328}
+    ...> |> Crux.Structs.resolve_id(Crux.Structs.User)
+    218348062828003328
+
+    # Incorrect type
+    iex> %Crux.Structs.Role{id: 222079439876390922}
+    ...> |> Crux.Structs.resolve_id(Crux.Structs.Emoji)
+    nil
+
+    ```
+  """
+  @spec resolve_id(nil, target :: module()) :: nil
+  @spec resolve_id(Snowflake.t(), target :: module()) :: Snowflake.t()
+  @spec resolve_id(map(), target :: module()) :: Snowflake.t() | nil
+
+  def resolve_id(data, target) do
+    Code.ensure_loaded(target)
+
+    if :erlang.function_exported(target, :resolve_id, 1) do
+      target.resolve_id(data)
+    else
+      case data do
+        %^target{id: id} when not is_nil(id) ->
+          resolve_id(id)
+
+        %{} ->
+          nil
+
+        _ ->
+          resolve_id(data)
+      end
+    end
+  end
+
+  @doc false
+  def resolve_id(snowflake) when Snowflake.is_snowflake(snowflake) do
+    snowflake
+  end
+
+  def resolve_id(string) when is_binary(string) do
+    case Snowflake.parse(string) do
+      :error ->
+        nil
+
+      snowflake ->
+        snowflake
+    end
+  end
+
+  def resolve_id(_), do: nil
 end

--- a/lib/structs.ex
+++ b/lib/structs.ex
@@ -149,9 +149,6 @@ defmodule Crux.Structs do
         %^target{id: id} when not is_nil(id) ->
           resolve_id(id)
 
-        %{} ->
-          nil
-
         _ ->
           resolve_id(data)
       end
@@ -176,5 +173,6 @@ defmodule Crux.Structs do
     end
   end
 
-  def resolve_id(_), do: nil
+  def resolve_id(%{}), do: nil
+  def resolve_id(nil), do: nil
 end

--- a/lib/structs.ex
+++ b/lib/structs.ex
@@ -159,6 +159,9 @@ defmodule Crux.Structs do
   end
 
   @doc false
+  @spec resolve_id(Snowflake.t()) :: Snowflake.t()
+  @spec resolve_id(String.t()) :: Snowflake.t() | nil
+  @spec resolve_id(nil) :: nil
   def resolve_id(snowflake) when Snowflake.is_snowflake(snowflake) do
     snowflake
   end

--- a/lib/structs/audit_log.ex
+++ b/lib/structs/audit_log.ex
@@ -5,7 +5,7 @@ defmodule Crux.Structs.AuditLog do
 
   @behaviour Crux.Structs
 
-  alias Crux.Structs.{AuditLogEntry, User, Util, Webhook}
+  alias Crux.Structs.{AuditLog, AuditLogEntry, Snowflake, User, Util, Webhook}
   require Util
 
   Util.modulesince("0.1.6")
@@ -23,6 +23,12 @@ defmodule Crux.Structs.AuditLog do
           users: %{Snowflake.t() => User.t()},
           audit_log_entries: %{Snowflake.t() => AuditLogEntry.t()}
         }
+
+  @typedoc """
+    All available types that can be resolved into an audit log id.
+  """
+  Util.typesince("0.2.1")
+  @type id_resolvable() :: AuditLog.t() | Snowflake.t() | String.t()
 
   @doc """
     Creates a `t:Crux.Structs.AuditLog.t/0` struct from raw data.

--- a/lib/structs/channel.ex
+++ b/lib/structs/channel.ex
@@ -31,8 +31,9 @@ defmodule Crux.Structs.Channel do
 
   @behaviour Crux.Structs
 
-  alias Crux.Structs.{Overwrite, Snowflake, Util}
+  alias Crux.Structs.{Channel, Message, Overwrite, Snowflake, Util}
   require Util
+  require Snowflake
 
   Util.modulesince("0.1.0")
 
@@ -79,6 +80,49 @@ defmodule Crux.Structs.Channel do
           type: integer(),
           user_limit: non_neg_integer()
         }
+
+  @typedoc """
+    All available types that can be resolved into a channel id.
+  """
+  Util.typesince("0.2.1")
+  @type id_resolvable() :: Message.t() | Channel.t() | Snowflake.t() | String.t()
+
+  @doc """
+    Resolves the id of a `t:Crux.Structs.Channel.t/0`.
+
+  > Automatically invoked by `Crux.Structs.resolve_id/2`.
+
+    ```elixir
+    iex> %Crux.Structs.Message{channel_id: 222079895583457280}
+    ...> |> Crux.Structs.Channel.resolve_id()
+    222079895583457280
+
+    iex> %Crux.Structs.Channel{id: 222079895583457280}
+    ...> |> Crux.Structs.Channel.resolve_id()
+    222079895583457280
+
+    iex> 222079895583457280
+    ...> |> Crux.Structs.Channel.resolve_id()
+    222079895583457280
+
+    iex> "222079895583457280"
+    ...> |> Crux.Structs.Channel.resolve_id()
+    222079895583457280
+
+    ```
+  """
+  @spec resolve_id(id_resolvable()) :: Snowflake.t() | nil
+  Util.since("0.2.1")
+
+  def resolve_id(%Message{channel_id: channel_id}) do
+    resolve_id(channel_id)
+  end
+
+  def resolve_id(%Channel{id: id}) do
+    resolve_id(id)
+  end
+
+  def resolve_id(data), do: Crux.Structs.resolve_id(data)
 
   @doc """
     Creates a `t:Crux.Structs.Channel.t/0` struct from raw data.

--- a/lib/structs/channel.ex
+++ b/lib/structs/channel.ex
@@ -31,6 +31,7 @@ defmodule Crux.Structs.Channel do
 
   @behaviour Crux.Structs
 
+  alias Crux.Structs
   alias Crux.Structs.{Channel, Message, Overwrite, Snowflake, Util}
   require Util
   require Snowflake
@@ -122,7 +123,7 @@ defmodule Crux.Structs.Channel do
     resolve_id(id)
   end
 
-  def resolve_id(data), do: Crux.Structs.resolve_id(data)
+  def resolve_id(data), do: Structs.resolve_id(data)
 
   @doc """
     Creates a `t:Crux.Structs.Channel.t/0` struct from raw data.

--- a/lib/structs/channel.ex
+++ b/lib/structs/channel.ex
@@ -125,6 +125,76 @@ defmodule Crux.Structs.Channel do
 
   def resolve_id(data), do: Structs.resolve_id(data)
 
+  @typedoc """
+    All available types that can be resolved into a channel position.
+  """
+  Util.typesince("0.2.1")
+
+  @type position_resolvable() ::
+          Channel.t()
+          | %{channel: id_resolvable(), position: integer()}
+          | {id_resolvable, integer()}
+          | %{id: id_resolvable(), position: integer()}
+
+  @doc """
+    Resolves a `t:position_resolvable/0` into a channel position.
+
+  ## Examples
+
+    ```elixir
+    iex> %Crux.Structs.Channel{id: 222079895583457280, position: 5}
+    ...> |> Crux.Structs.Channel.resolve_position()
+    %{id: 222079895583457280, position: 5}
+
+    iex> {%Crux.Structs.Channel{id: 222079895583457280}, 5}
+    ...> |> Crux.Structs.Channel.resolve_position()
+    %{id: 222079895583457280, position: 5}
+
+    iex> {222079895583457280, 5}
+    ...> |> Crux.Structs.Channel.resolve_position()
+    %{id: 222079895583457280, position: 5}
+
+    iex> %{id: 222079895583457280, position: 5}
+    ...> |> Crux.Structs.Channel.resolve_position()
+    %{id: 222079895583457280, position: 5}
+
+    iex> {nil, 5}
+    ...> |> Crux.Structs.Channel.resolve_position()
+    nil
+
+    ```
+
+  """
+  Util.since("0.2.1")
+  @spec resolve_position(position_resolvable()) :: %{id: Snowflake.t(), position: integer()} | nil
+  def resolve_position(%Channel{id: id, position: position}) do
+    validate_position(%{id: id, position: position})
+  end
+
+  def resolve_position(%{channel: resolvable, position: position}) do
+    validate_position(%{id: resolve_id(resolvable), position: position})
+  end
+
+  def resolve_position(%{id: resolvable, position: position}) do
+    validate_position(%{id: resolve_id(resolvable), position: position})
+  end
+
+  def resolve_position({resolvable, position}) do
+    validate_position(%{id: resolve_id(resolvable), position: position})
+  end
+
+  @spec validate_position(%{id: Snowflake.t(), position: integer()}) :: %{
+          id: Snowflake.t(),
+          position: integer()
+        }
+  @spec validate_position(%{id: nil, position: integer()}) :: nil
+  defp validate_position(%{id: nil, position: _}), do: nil
+
+  defp validate_position(%{id: _id, position: position} = entry)
+       when is_integer(position) do
+    entry
+  end
+
   @doc """
     Creates a `t:Crux.Structs.Channel.t/0` struct from raw data.
 

--- a/lib/structs/channel.ex
+++ b/lib/structs/channel.ex
@@ -34,7 +34,6 @@ defmodule Crux.Structs.Channel do
   alias Crux.Structs
   alias Crux.Structs.{Channel, Message, Overwrite, Snowflake, Util}
   require Util
-  require Snowflake
 
   Util.modulesince("0.1.0")
 
@@ -123,7 +122,7 @@ defmodule Crux.Structs.Channel do
     resolve_id(id)
   end
 
-  def resolve_id(data), do: Structs.resolve_id(data)
+  def resolve_id(resolvable), do: Structs.resolve_id(resolvable)
 
   @typedoc """
     All available types that can be resolved into a channel position.
@@ -133,7 +132,7 @@ defmodule Crux.Structs.Channel do
   @type position_resolvable() ::
           Channel.t()
           | %{channel: id_resolvable(), position: integer()}
-          | {id_resolvable, integer()}
+          | {id_resolvable(), integer()}
           | %{id: id_resolvable(), position: integer()}
 
   @doc """
@@ -163,10 +162,11 @@ defmodule Crux.Structs.Channel do
     nil
 
     ```
-
   """
   Util.since("0.2.1")
   @spec resolve_position(position_resolvable()) :: %{id: Snowflake.t(), position: integer()} | nil
+  def resolve_position(resolvable)
+
   def resolve_position(%Channel{id: id, position: position}) do
     validate_position(%{id: id, position: position})
   end

--- a/lib/structs/emoji.ex
+++ b/lib/structs/emoji.ex
@@ -102,6 +102,14 @@ defmodule Crux.Structs.Emoji do
     struct(__MODULE__, emoji)
   end
 
+  @typedoc """
+    All available types that can be resolved into a discord emoji identifier.
+
+  > String.t() stands for an already encoded unicode emoji.
+  """
+  Util.typesince("0.2.1")
+  @type identifier_resolvable() :: Emoji.t() | Reaction.t() | String.t()
+
   @doc ~S"""
     Converts an `t:Crux.Structs.Emoji.t/0`, a `t:Crux.Structs.Reaction.t/0`, or a `t:String.t/0` to its discord identifier format.
 
@@ -145,8 +153,7 @@ defmodule Crux.Structs.Emoji do
 
     ```
   """
-  @spec to_identifier(emoji :: Crux.Structs.Emoji.t() | Crux.Structs.Reaction.t() | String.t()) ::
-          String.t()
+  @spec to_identifier(emoji :: identifier_resolvable()) :: String.t()
   Util.since("0.1.1")
   def to_identifier(%Crux.Structs.Reaction{emoji: emoji}), do: to_identifier(emoji)
   def to_identifier(%__MODULE__{id: nil, name: name}), do: URI.encode_www_form(name)

--- a/lib/structs/emoji.ex
+++ b/lib/structs/emoji.ex
@@ -11,7 +11,6 @@ defmodule Crux.Structs.Emoji do
   alias Crux.Structs
   alias Crux.Structs.{Emoji, Reaction, Snowflake, Util}
   require Util
-  require Snowflake
 
   Util.modulesince("0.1.0")
 
@@ -78,7 +77,7 @@ defmodule Crux.Structs.Emoji do
     resolve_id(id)
   end
 
-  def resolve_id(data), do: Structs.resolve_id(data)
+  def resolve_id(resolvable), do: Structs.resolve_id(resolvable)
 
   @doc """
     Creates a `t:Crux.Structs.Emoji.t/0` struct from raw data.

--- a/lib/structs/emoji.ex
+++ b/lib/structs/emoji.ex
@@ -8,6 +8,7 @@ defmodule Crux.Structs.Emoji do
 
   @behaviour Crux.Structs
 
+  alias Crux.Structs
   alias Crux.Structs.{Emoji, Reaction, Snowflake, Util}
   require Util
   require Snowflake
@@ -77,7 +78,7 @@ defmodule Crux.Structs.Emoji do
     resolve_id(id)
   end
 
-  def resolve_id(data), do: Crux.Structs.resolve_id(data)
+  def resolve_id(data), do: Structs.resolve_id(data)
 
   @doc """
     Creates a `t:Crux.Structs.Emoji.t/0` struct from raw data.

--- a/lib/structs/emoji.ex
+++ b/lib/structs/emoji.ex
@@ -8,8 +8,9 @@ defmodule Crux.Structs.Emoji do
 
   @behaviour Crux.Structs
 
-  alias Crux.Structs.{Emoji, Snowflake, Util}
+  alias Crux.Structs.{Emoji, Reaction, Snowflake, Util}
   require Util
+  require Snowflake
 
   Util.modulesince("0.1.0")
 
@@ -34,6 +35,49 @@ defmodule Crux.Structs.Emoji do
           require_colons: boolean() | nil,
           managed: boolean() | nil
         }
+
+  @typedoc """
+    All available types that can be resolved into an emoji id.
+  """
+  Util.typesince("0.2.1")
+  @type id_resolvable() :: Reaction.t() | Emoji.t() | Snowflake.t() | String.t()
+
+  @doc """
+    Resolves the id of a `t:Crux.Structs.Emoji.t/0`.
+
+  > Automatically invoked by `Crux.Structs.resolve_id/2`.
+
+    ```elixir
+    iex> %Crux.Structs.Emoji{id: 618731477143912448}
+    ...> |> Crux.Structs.Emoji.resolve_id()
+    618731477143912448
+
+    iex> %Crux.Structs.Reaction{emoji: %Crux.Structs.Emoji{id: 618731477143912448}}
+    ...> |> Crux.Structs.Emoji.resolve_id()
+    618731477143912448
+
+    iex> 618731477143912448
+    ...> |> Crux.Structs.Emoji.resolve_id()
+    618731477143912448
+
+    iex> "618731477143912448"
+    ...> |> Crux.Structs.Emoji.resolve_id()
+    618731477143912448
+
+    ```
+  """
+  @spec resolve_id(id_resolvable()) :: Snowflake.t() | nil
+  Util.since("0.2.1")
+
+  def resolve_id(%Reaction{emoji: emoji}) do
+    resolve_id(emoji)
+  end
+
+  def resolve_id(%Emoji{id: id}) do
+    resolve_id(id)
+  end
+
+  def resolve_id(data), do: Crux.Structs.resolve_id(data)
 
   @doc """
     Creates a `t:Crux.Structs.Emoji.t/0` struct from raw data.

--- a/lib/structs/guild.ex
+++ b/lib/structs/guild.ex
@@ -11,8 +11,9 @@ defmodule Crux.Structs.Guild do
   @behaviour Crux.Structs
 
   alias Crux.Structs
-  alias Crux.Structs.{Guild, Member, Role, Snowflake, Util, VoiceState}
+  alias Crux.Structs.{Channel, Guild, Member, Message, Role, Snowflake, Util, VoiceState}
   require Util
+  require Snowflake
 
   Util.modulesince("0.1.0")
 
@@ -102,6 +103,67 @@ defmodule Crux.Structs.Guild do
           embed_enabled: boolean(),
           widget_enabled: boolean()
         }
+
+  @typedoc """
+    All available types that can be resolved into a guild id.
+  """
+  Util.typesince("0.2.1")
+  @type id_resolvable() :: Guild.t() | Channel.t() | Message.t() | Snowflake.t()
+
+  @doc """
+    Resolves the id of a `t:Crux.Structs.Guild.t/0`.
+
+  > Automatically invoked by `Crux.Structs.resolve_id/2`.
+
+
+    ```elixir
+    iex> %Crux.Structs.Guild{id: 516569101267894284}
+    ...> |> Crux.Structs.Guild.resolve_id()
+    516569101267894284
+
+    iex> %Crux.Structs.Channel{guild_id: 516569101267894284}
+    ...> |> Crux.Structs.Guild.resolve_id()
+    516569101267894284
+
+    iex> %Crux.Structs.Message{guild_id: 516569101267894284}
+    ...> |> Crux.Structs.Guild.resolve_id()
+    516569101267894284
+
+    iex> 516569101267894284
+    ...> |> Crux.Structs.Guild.resolve_id()
+    516569101267894284
+
+    iex> "516569101267894284"
+    ...> |> Crux.Structs.Guild.resolve_id()
+    516569101267894284
+
+    # DMs
+    iex> %Crux.Structs.Channel{guild_id: nil}
+    ...> |> Crux.Structs.Guild.resolve_id()
+    nil
+
+    iex> %Crux.Structs.Message{guild_id: nil}
+    ...> |> Crux.Structs.Guild.resolve_id()
+    nil
+
+    ```
+  """
+  @spec resolve_id(id_resolvable()) :: Snowflake.t() | nil
+  Util.since("0.2.1")
+
+  def resolve_id(%Guild{id: id}) do
+    resolve_id(id)
+  end
+
+  def resolve_id(%Channel{guild_id: guild_id}) do
+    resolve_id(guild_id)
+  end
+
+  def resolve_id(%Message{guild_id: guild_id}) do
+    resolve_id(guild_id)
+  end
+
+  def resolve_id(data), do: Crux.Structs.resolve_id(data)
 
   @doc """
     Creates a `t:Crux.Structs.Guild/0` struct from raw data.

--- a/lib/structs/guild.ex
+++ b/lib/structs/guild.ex
@@ -13,7 +13,6 @@ defmodule Crux.Structs.Guild do
   alias Crux.Structs
   alias Crux.Structs.{Channel, Guild, Member, Message, Role, Snowflake, Util, VoiceState}
   require Util
-  require Snowflake
 
   Util.modulesince("0.1.0")
 
@@ -163,7 +162,7 @@ defmodule Crux.Structs.Guild do
     resolve_id(guild_id)
   end
 
-  def resolve_id(data), do: Structs.resolve_id(data)
+  def resolve_id(resolvable), do: Structs.resolve_id(resolvable)
 
   @doc """
     Creates a `t:Crux.Structs.Guild/0` struct from raw data.

--- a/lib/structs/guild.ex
+++ b/lib/structs/guild.ex
@@ -163,7 +163,7 @@ defmodule Crux.Structs.Guild do
     resolve_id(guild_id)
   end
 
-  def resolve_id(data), do: Crux.Structs.resolve_id(data)
+  def resolve_id(data), do: Structs.resolve_id(data)
 
   @doc """
     Creates a `t:Crux.Structs.Guild/0` struct from raw data.

--- a/lib/structs/member.ex
+++ b/lib/structs/member.ex
@@ -52,7 +52,7 @@ defmodule Crux.Structs.Member do
   @spec resolve_id(id_resolvable()) :: Snowflake.t() | nil
   Util.since("0.2.1")
 
-  defdelegate resolve_id(data), to: User
+  defdelegate resolve_id(resolvable), to: User
 
   @doc """
     Creates a `t:Crux.Structs.Member.t/0` struct from raw data.

--- a/lib/structs/member.ex
+++ b/lib/structs/member.ex
@@ -8,7 +8,7 @@ defmodule Crux.Structs.Member do
 
   @behaviour Crux.Structs
 
-  alias Crux.Structs.{Member, Snowflake, User, Util, VoiceState}
+  alias Crux.Structs.{Member, Snowflake, User, Util}
   require Util
 
   Util.modulesince("0.1.0")
@@ -47,33 +47,7 @@ defmodule Crux.Structs.Member do
 
   > Automatically invoked by `Crux.Structs.resolve_id/2`.
 
-
-    ```elixir
-    iex> %Crux.Structs.User{id: 218348062828003328}
-    ...> |> Crux.Structs.Member.resolve_id()
-    218348062828003328
-
-    iex> %Crux.Structs.Member{user: 218348062828003328}
-    ...> |> Crux.Structs.Member.resolve_id()
-    218348062828003328
-
-    iex> %Crux.Structs.Message{author: %Crux.Structs.User{id: 218348062828003328}}
-    ...> |> Crux.Structs.Member.resolve_id()
-    218348062828003328
-
-    iex> %Crux.Structs.VoiceState{user_id: 218348062828003328}
-    ...> |> Crux.Structs.Member.resolve_id()
-    218348062828003328
-
-    iex> 218348062828003328
-    ...> |> Crux.Structs.Member.resolve_id()
-    218348062828003328
-
-    iex> "218348062828003328"
-    ...> |> Crux.Structs.Member.resolve_id()
-    218348062828003328
-
-    ```
+    For examples see `Crux.Structs.User.resolve_id/1`.
   """
   @spec resolve_id(id_resolvable()) :: Snowflake.t() | nil
   Util.since("0.2.1")

--- a/lib/structs/member.ex
+++ b/lib/structs/member.ex
@@ -42,7 +42,6 @@ defmodule Crux.Structs.Member do
 
   @type id_resolvable() :: User.id_resolvable()
 
-
   @doc """
     Resolves the id of a `t:Crux.Structs.Member.t/0`.
 

--- a/lib/structs/member.ex
+++ b/lib/structs/member.ex
@@ -8,7 +8,7 @@ defmodule Crux.Structs.Member do
 
   @behaviour Crux.Structs
 
-  alias Crux.Structs.{Member, Snowflake, Util}
+  alias Crux.Structs.{Member, Snowflake, User, Util, VoiceState}
   require Util
 
   Util.modulesince("0.1.0")
@@ -34,6 +34,52 @@ defmodule Crux.Structs.Member do
           mute: boolean() | nil,
           guild_id: Snowflake.t() | nil
         }
+
+  @typedoc """
+    All available types that can be resolved into a user id.
+  """
+  Util.typesince("0.2.1")
+
+  @type id_resolvable() :: User.id_resolvable()
+
+
+  @doc """
+    Resolves the id of a `t:Crux.Structs.Member.t/0`.
+
+  > Automatically invoked by `Crux.Structs.resolve_id/2`.
+
+
+    ```elixir
+    iex> %Crux.Structs.User{id: 218348062828003328}
+    ...> |> Crux.Structs.Member.resolve_id()
+    218348062828003328
+
+    iex> %Crux.Structs.Member{user: 218348062828003328}
+    ...> |> Crux.Structs.Member.resolve_id()
+    218348062828003328
+
+    iex> %Crux.Structs.Message{author: %Crux.Structs.User{id: 218348062828003328}}
+    ...> |> Crux.Structs.Member.resolve_id()
+    218348062828003328
+
+    iex> %Crux.Structs.VoiceState{user_id: 218348062828003328}
+    ...> |> Crux.Structs.Member.resolve_id()
+    218348062828003328
+
+    iex> 218348062828003328
+    ...> |> Crux.Structs.Member.resolve_id()
+    218348062828003328
+
+    iex> "218348062828003328"
+    ...> |> Crux.Structs.Member.resolve_id()
+    218348062828003328
+
+    ```
+  """
+  @spec resolve_id(id_resolvable()) :: Snowflake.t() | nil
+  Util.since("0.2.1")
+
+  defdelegate resolve_id(data), to: User
 
   @doc """
     Creates a `t:Crux.Structs.Member.t/0` struct from raw data.

--- a/lib/structs/message.ex
+++ b/lib/structs/message.ex
@@ -11,7 +11,6 @@ defmodule Crux.Structs.Message do
   alias Crux.Structs
   alias Crux.Structs.{Attachment, Embed, Member, Message, Reaction, Snowflake, User, Util}
   require Util
-  require Snowflake
 
   Util.modulesince("0.1.0")
 
@@ -111,22 +110,6 @@ defmodule Crux.Structs.Message do
         }
 
   @type id_resolvable() :: Message.t() | Snowflake.t() | String.t()
-
-  @doc """
-    Resolves the id of a `t:Crux.Structs.Message.t/0`.
-
-  > Automatically invoked by `Crux.Structs.resolve_id/2`.
-
-    For examples see `Crux.Structs.User.resolve_id/1`.
-  """
-  @spec resolve_id(id_resolvable()) :: Snowflake.t() | nil
-  Util.since("0.2.1")
-
-  def resolve_id(%Message{id: id}) do
-    resolve_id(id)
-  end
-
-  def resolve_id(data), do: Structs.resolve_id(data)
 
   @doc """
     Creates a `t:Crux.Structs.Message.t/0` struct from raw data.

--- a/lib/structs/message.ex
+++ b/lib/structs/message.ex
@@ -140,7 +140,7 @@ defmodule Crux.Structs.Message do
     resolve_id(id)
   end
 
-  def resolve_id(data), do: Crux.Structs.resolve_id(data)
+  def resolve_id(data), do: Structs.resolve_id(data)
 
   @doc """
     Creates a `t:Crux.Structs.Message.t/0` struct from raw data.

--- a/lib/structs/message.ex
+++ b/lib/structs/message.ex
@@ -117,21 +117,7 @@ defmodule Crux.Structs.Message do
 
   > Automatically invoked by `Crux.Structs.resolve_id/2`.
 
-
-    ```elixir
-    iex> %Crux.Structs.Message{id: 618790661260574731}
-    ...> |> Crux.Structs.Message.resolve_id()
-    618790661260574731
-
-    iex> 618790661260574731
-    ...> |> Crux.Structs.Message.resolve_id()
-    618790661260574731
-
-    iex> "618790661260574731"
-    ...> |> Crux.Structs.Message.resolve_id()
-    618790661260574731
-
-    ```
+    For examples see `Crux.Structs.User.resolve_id/1`.
   """
   @spec resolve_id(id_resolvable()) :: Snowflake.t() | nil
   Util.since("0.2.1")

--- a/lib/structs/message.ex
+++ b/lib/structs/message.ex
@@ -109,6 +109,10 @@ defmodule Crux.Structs.Message do
           webhook_id: Snowflake.t() | nil
         }
 
+  @typedoc """
+    All available types that can be resolved into a message id.
+  """
+  Util.typesince("0.2.1")
   @type id_resolvable() :: Message.t() | Snowflake.t() | String.t()
 
   @doc """

--- a/lib/structs/message.ex
+++ b/lib/structs/message.ex
@@ -11,6 +11,7 @@ defmodule Crux.Structs.Message do
   alias Crux.Structs
   alias Crux.Structs.{Attachment, Embed, Member, Message, Reaction, Snowflake, User, Util}
   require Util
+  require Snowflake
 
   Util.modulesince("0.1.0")
 
@@ -108,6 +109,38 @@ defmodule Crux.Structs.Message do
           type: integer(),
           webhook_id: Snowflake.t() | nil
         }
+
+  @type id_resolvable() :: Message.t() | Snowflake.t() | String.t()
+
+  @doc """
+    Resolves the id of a `t:Crux.Structs.Message.t/0`.
+
+  > Automatically invoked by `Crux.Structs.resolve_id/2`.
+
+
+    ```elixir
+    iex> %Crux.Structs.Message{id: 618790661260574731}
+    ...> |> Crux.Structs.Message.resolve_id()
+    618790661260574731
+
+    iex> 618790661260574731
+    ...> |> Crux.Structs.Message.resolve_id()
+    618790661260574731
+
+    iex> "618790661260574731"
+    ...> |> Crux.Structs.Message.resolve_id()
+    618790661260574731
+
+    ```
+  """
+  @spec resolve_id(id_resolvable()) :: Snowflake.t() | nil
+  Util.since("0.2.1")
+
+  def resolve_id(%Message{id: id}) do
+    resolve_id(id)
+  end
+
+  def resolve_id(data), do: Crux.Structs.resolve_id(data)
 
   @doc """
     Creates a `t:Crux.Structs.Message.t/0` struct from raw data.

--- a/lib/structs/overwrite.ex
+++ b/lib/structs/overwrite.ex
@@ -5,8 +5,9 @@ defmodule Crux.Structs.Overwrite do
 
   @behaviour Crux.Structs
 
-  alias Crux.Structs.{Snowflake, Util}
+  alias Crux.Structs.{Overwrite, Role, Snowflake, User, Util}
   require Util
+  require Snowflake
 
   Util.modulesince("0.1.0")
 
@@ -25,6 +26,70 @@ defmodule Crux.Structs.Overwrite do
           allow: integer(),
           deny: integer()
         }
+
+  @typedoc """
+    All available types that can be resolved into a target for a permission overwrite
+  """
+  Util.typesince("0.2.1")
+  @type target_resolvable() :: Overwrite.t() | Role.t() | User.id_resolvable()
+
+  @doc """
+    Resolves a `t:target_resolvable/0` into an overwrite target.
+
+  > Note that an id or string of it returns `:unknown` as type.
+
+  ## Examples
+
+    ```elixir
+    iex> %Crux.Structs.Overwrite{type: "member", id: 218348062828003328}
+    ...> |> Crux.Structs.Overwrite.resolve_target()
+    {"member", 218348062828003328}
+
+    iex> %Crux.Structs.Role{id: 376146940762783746}
+    ...> |> Crux.Structs.Overwrite.resolve_target()
+    {"role", 376146940762783746}
+
+    iex> %Crux.Structs.User{id: 218348062828003328}
+    ...> |> Crux.Structs.Overwrite.resolve_target()
+    {"member", 218348062828003328}
+
+    iex> %Crux.Structs.Member{user: 218348062828003328}
+    ...> |> Crux.Structs.Overwrite.resolve_target()
+    {"member", 218348062828003328}
+
+    iex> %Crux.Structs.Message{author: %Crux.Structs.User{id: 218348062828003328}}
+    ...> |> Crux.Structs.Overwrite.resolve_target()
+    {"member", 218348062828003328}
+
+    iex> %Crux.Structs.VoiceState{user_id: 218348062828003328}
+    ...> |> Crux.Structs.Overwrite.resolve_target()
+    {"member", 218348062828003328}
+
+    iex> 218348062828003328
+    ...> |> Crux.Structs.Overwrite.resolve_target()
+    {:unknown, 218348062828003328}
+
+    iex> "218348062828003328"
+    ...> |> Crux.Structs.Overwrite.resolve_target()
+    {:unknown, 218348062828003328}
+
+    iex> nil
+    ...> |> Crux.Structs.Overwrite.resolve_target()
+    nil
+
+    ```
+  """
+  @spec resolve_target(target_resolvable()) :: {String.t() | :unknown, Snowflake.t()}
+  def resolve_target(%Overwrite{id: id, type: type}), do: {type, id}
+  def resolve_target(%Role{id: id}), do: {"role", id}
+
+  def resolve_target(target) do
+    case Crux.Structs.resolve_id(target, User) do
+      nil -> nil
+      id when is_map(target) -> {"member", id}
+      id -> {:unknown, id}
+    end
+  end
 
   @doc """
     Creates a `t:Crux.Structs.Overwrite.t/0` struct from raw data.

--- a/lib/structs/overwrite.ex
+++ b/lib/structs/overwrite.ex
@@ -5,6 +5,7 @@ defmodule Crux.Structs.Overwrite do
 
   @behaviour Crux.Structs
 
+  alias Crux.Structs
   alias Crux.Structs.{Overwrite, Role, Snowflake, User, Util}
   require Util
   require Snowflake
@@ -84,7 +85,7 @@ defmodule Crux.Structs.Overwrite do
   def resolve_target(%Role{id: id}), do: {"role", id}
 
   def resolve_target(target) do
-    case Crux.Structs.resolve_id(target, User) do
+    case Structs.resolve_id(target, User) do
       nil -> nil
       id when is_map(target) -> {"member", id}
       id -> {:unknown, id}

--- a/lib/structs/overwrite.ex
+++ b/lib/structs/overwrite.ex
@@ -8,7 +8,6 @@ defmodule Crux.Structs.Overwrite do
   alias Crux.Structs
   alias Crux.Structs.{Overwrite, Role, Snowflake, User, Util}
   require Util
-  require Snowflake
 
   Util.modulesince("0.1.0")
 
@@ -84,10 +83,10 @@ defmodule Crux.Structs.Overwrite do
   def resolve_target(%Overwrite{id: id, type: type}), do: {type, id}
   def resolve_target(%Role{id: id}), do: {"role", id}
 
-  def resolve_target(target) do
-    case Structs.resolve_id(target, User) do
+  def resolve_target(resolvable) do
+    case Structs.resolve_id(resolvable, User) do
       nil -> nil
-      id when is_map(target) -> {"member", id}
+      id when is_map(resolvable) -> {"member", id}
       id -> {:unknown, id}
     end
   end

--- a/lib/structs/presence.ex
+++ b/lib/structs/presence.ex
@@ -42,7 +42,7 @@ defmodule Crux.Structs.Presence do
   @type id_resolvable :: User.id_resolvable()
 
   @doc """
-    Resolves the id of a `Crux.Structs.Presence.t/0`
+    Resolves the id of a `t:Crux.Structs.Presence.t/0`
 
   > Automatically invoked by `Crux.Structs.resolve_id/2`
 
@@ -51,7 +51,7 @@ defmodule Crux.Structs.Presence do
   @spec resolve_id(id_resolvable()) :: Snowflake.t() | nil
   Util.since("0.2.1")
 
-  defdelegate resolve_id(data), to: User
+  defdelegate resolve_id(resolvable), to: User
 
   @doc """
     Creates a `t:Crux.Structs.Presence.t/0` struct from raw data.

--- a/lib/structs/presence.ex
+++ b/lib/structs/presence.ex
@@ -8,7 +8,7 @@ defmodule Crux.Structs.Presence do
 
   @behaviour Crux.Structs
 
-  alias Crux.Structs.Util
+  alias Crux.Structs.{User, Util}
   require Util
 
   Util.modulesince("0.1.0")
@@ -34,6 +34,24 @@ defmodule Crux.Structs.Presence do
           activities: [map()],
           client_status: %{required(atom()) => atom()}
         }
+
+  @typedoc """
+    All available types that can be resolved into a user id.
+  """
+  Util.typesince("0.2.1")
+  @type id_resolvable :: User.id_resolvable()
+
+  @doc """
+    Resolves the id of a `Crux.Structs.Presence.t/0`
+
+  > Automatically invoked by `Crux.Structs.resolve_id/2`
+
+    For examples see `Crux.Structs.User.resolve_id/1`
+  """
+  @spec resolve_id(id_resolvable()) :: Snowflake.t() | nil
+  Util.since("0.2.1")
+
+  defdelegate resolve_id(data), to: User
 
   @doc """
     Creates a `t:Crux.Structs.Presence.t/0` struct from raw data.

--- a/lib/structs/reaction.ex
+++ b/lib/structs/reaction.ex
@@ -58,7 +58,7 @@ defmodule Crux.Structs.Reaction do
   @spec resolve_id(id_resolvable()) :: Snowflake.t() | nil
   Util.since("0.2.1")
 
-  defdelegate resolve_id(data), to: Emoji
+  defdelegate resolve_id(resolvable), to: Emoji
 
   @doc """
     Creates a `t:Crux.Structs.Presence.t/0` struct from raw data.

--- a/lib/structs/reaction.ex
+++ b/lib/structs/reaction.ex
@@ -25,6 +25,40 @@ defmodule Crux.Structs.Reaction do
           emoji: Emoji.t()
         }
 
+  @typedoc """
+    All available types that can be resolved into a reaction / emoji id.
+  """
+  Util.typesince("0.2.1")
+  @type id_resolvable() :: Reaction.t() | Emoji.t() | Snowflake.t() | String.t()
+  @doc """
+    Resolves the id of a `t:Crux.Structs.Reaction.t/0`.
+
+  > Automatically invoked by `Crux.Structs.resolve_id/2`.
+
+    ```elixir
+    iex> %Crux.Structs.Reaction{emoji: %Crux.Structs.Emoji{id: 618731477143912448}}
+    ...> |> Crux.Structs.Reaction.resolve_id()
+    618731477143912448
+
+    iex> %Crux.Structs.Emoji{id: 618731477143912448}
+    ...> |> Crux.Structs.Reaction.resolve_id()
+    618731477143912448
+
+    iex> 618731477143912448
+    ...> |> Crux.Structs.Reaction.resolve_id()
+    618731477143912448
+
+    iex> "618731477143912448"
+    ...> |> Crux.Structs.Reaction.resolve_id()
+    618731477143912448
+
+    ```
+  """
+  @spec resolve_id(id_resolvable()) :: Snowflake.t() | nil
+  Util.since("0.2.1")
+
+  defdelegate resolve_id(data), to: Emoji
+
   @doc """
     Creates a `t:Crux.Structs.Presence.t/0` struct from raw data.
 

--- a/lib/structs/reaction.ex
+++ b/lib/structs/reaction.ex
@@ -30,6 +30,7 @@ defmodule Crux.Structs.Reaction do
   """
   Util.typesince("0.2.1")
   @type id_resolvable() :: Reaction.t() | Emoji.t() | Snowflake.t() | String.t()
+
   @doc """
     Resolves the id of a `t:Crux.Structs.Reaction.t/0`.
 

--- a/lib/structs/role.ex
+++ b/lib/structs/role.ex
@@ -37,24 +37,6 @@ defmodule Crux.Structs.Role do
           guild_id: Snowflake.t()
         }
 
-  @doc """
-    Creates a `t:Crux.Structs.Role.t/0` struct from raw data.
-
-  > Automatically invoked by `Crux.Structs.create/2`.
-  """
-  @spec create(data :: map()) :: t()
-  Util.since("0.1.0")
-
-  def create(data) do
-    role =
-      data
-      |> Util.atomify()
-      |> Map.update!(:id, &Snowflake.to_snowflake/1)
-      |> Map.update(:guild_id, nil, &Snowflake.to_snowflake/1)
-
-    struct(__MODULE__, role)
-  end
-
   @typedoc """
     All available types that can be resolved into a role id.
   """
@@ -128,6 +110,24 @@ defmodule Crux.Structs.Role do
   defp validate_position(%{id: _id, position: position} = entry)
        when is_integer(position) do
     entry
+  end
+
+  @doc """
+    Creates a `t:Crux.Structs.Role.t/0` struct from raw data.
+
+  > Automatically invoked by `Crux.Structs.create/2`.
+  """
+  @spec create(data :: map()) :: t()
+  Util.since("0.1.0")
+
+  def create(data) do
+    role =
+      data
+      |> Util.atomify()
+      |> Map.update!(:id, &Snowflake.to_snowflake/1)
+      |> Map.update(:guild_id, nil, &Snowflake.to_snowflake/1)
+
+    struct(__MODULE__, role)
   end
 
   @doc ~S"""

--- a/lib/structs/role.ex
+++ b/lib/structs/role.ex
@@ -5,6 +5,7 @@ defmodule Crux.Structs.Role do
 
   @behaviour Crux.Structs
 
+  alias Crux.Structs
   alias Crux.Structs.{Role, Snowflake, Util}
   require Util
 
@@ -54,10 +55,85 @@ defmodule Crux.Structs.Role do
     struct(__MODULE__, role)
   end
 
+  @typedoc """
+    All available types that can be resolved into a role id.
+  """
+  Util.typesince("0.2.1")
+  @type id_resolvable() :: Role.t() | Snowflake.t() | String.t() | nil
+
+  @typedoc """
+    All available types that can be resolved into a role position.
+  """
+  Util.typesince("0.2.1")
+
+  @type position_resolvable() ::
+          Role.t()
+          | %{role: id_resolvable(), position: integer()}
+          | {id_resolvable(), integer()}
+          | %{id: id_resolvable(), position: integer()}
+
+  @doc """
+    Resolves a `t:position_resolvable/0` into a role position.
+
+  ## Examples
+
+    ```elixir
+    iex> {%Crux.Structs.Role{id: 373405430589816834}, 5}
+    ...> |> Crux.Structs.Role.resolve_position()
+    %{id: 373405430589816834, position: 5}
+
+    iex> %{id: 373405430589816834, position: 5}
+    ...> |> Crux.Structs.Role.resolve_position()
+    %{id: 373405430589816834, position: 5}
+
+    iex> %{role: %Crux.Structs.Role{id: 373405430589816834}, position: 5}
+    ...> |> Crux.Structs.Role.resolve_position()
+    %{id: 373405430589816834, position: 5}
+
+    iex> {373405430589816834, 5}
+    ...> |> Crux.Structs.Role.resolve_position()
+    %{id: 373405430589816834, position: 5}
+
+    iex> {nil, 5}
+    ...> |> Crux.Structs.Role.resolve_position()
+    nil
+
+    ```
+  """
+  Util.since("0.2.1")
+  @spec resolve_position(position_resolvable()) :: %{id: Snowflake.t(), position: integer()} | nil
+  def resolve_position(%Role{id: id, position: position}) do
+    validate_position(%{id: id, position: position})
+  end
+
+  def resolve_position(%{role: resolvable, position: position}) do
+    validate_position(%{id: Structs.resolve_id(resolvable, Role), position: position})
+  end
+
+  def resolve_position({resolvable, position}) do
+    validate_position(%{id: Structs.resolve_id(resolvable, Role), position: position})
+  end
+
+  def resolve_position(%{id: resolvable, position: position}) do
+    validate_position(%{id: Structs.resolve_id(resolvable, Role), position: position})
+  end
+
+  @spec validate_position(%{id: Snowflake.t(), position: integer()}) :: %{
+          id: Snowflake.t(),
+          position: integer()
+        }
+  @spec validate_position(%{id: nil, position: integer()}) :: nil
+  defp validate_position(%{id: nil, position: _}), do: nil
+
+  defp validate_position(%{id: _id, position: position} = entry)
+       when is_integer(position) do
+    entry
+  end
+
   @doc ~S"""
     Converts a `t:Crux.Structs.Role.t/0` into its discord mention format.
 
-    ## Example
+  ## Example
 
     ```elixir
   iex> %Crux.Structs.Role{id: 376146940762783746}

--- a/lib/structs/role.ex
+++ b/lib/structs/role.ex
@@ -84,6 +84,8 @@ defmodule Crux.Structs.Role do
   """
   Util.since("0.2.1")
   @spec resolve_position(position_resolvable()) :: %{id: Snowflake.t(), position: integer()} | nil
+  def resolve_position(resolvable)
+
   def resolve_position(%Role{id: id, position: position}) do
     validate_position(%{id: id, position: position})
   end

--- a/lib/structs/snowflake.ex
+++ b/lib/structs/snowflake.ex
@@ -63,7 +63,7 @@ defmodule Crux.Structs.Snowflake.Parts do
       timestamp: ((snowflake &&& @timestamp_bitmask) >>> 22) + @discord_epoch,
       worker_id: (snowflake &&& @worker_id_bitmask) >>> 17,
       process_id: (snowflake &&& @process_id_bitmask) >>> 12,
-      increment: snowflake &&& @increment_bitmask
+      increment: snowflake &&& @increment_bitmask >>> 0
     }
   end
 
@@ -114,10 +114,16 @@ defmodule Crux.Structs.Snowflake do
   Util.typesince("0.2.1")
   @type t :: 0..0xFFFF_FFFF_FFFF_FFFF
 
+  @typedoc """
+    All valid types that can be resolved into a `t:t/0`.
+  """
+  Util.typesince("0.2.1")
+  @type resolvable :: String.t() | t()
+
   @doc """
     Returns `true` if `term` is a `t:t/0`; otherwise returns `false`..
   """
-  Util.typesince("0.2.1")
+  Util.since("0.2.1")
 
   defguard is_snowflake(snowflake)
            when is_integer(snowflake) and snowflake in 0..0xFFFF_FFFF_FFFF_FFFF
@@ -210,7 +216,7 @@ defmodule Crux.Structs.Snowflake do
   @doc """
     Converts a `t:String.t/0` to a `t:t/0` while allowing `t:t/0` to pass through.
 
-    Returns `:error` if the provided string is not an integer.
+    Returns `:error` if the provided string is not a `t:t/0`.
 
     ```elixir
     iex> Crux.Structs.Snowflake.parse("invalid")

--- a/lib/structs/snowflake.ex
+++ b/lib/structs/snowflake.ex
@@ -19,6 +19,8 @@ defmodule Crux.Structs.Snowflake.Parts do
   alias Crux.Structs.{Snowflake, Util}
   require Util
 
+  Util.modulesince("0.2.1")
+
   @discord_epoch 1_420_070_400_000
 
   @doc false

--- a/lib/structs/snowflake.ex
+++ b/lib/structs/snowflake.ex
@@ -233,10 +233,12 @@ defmodule Crux.Structs.Snowflake do
   end
 
   def parse(string) when is_binary(string) do
-    with {snowflake, ""} when is_snowflake(snowflake) <- Integer.parse(string) do
-      snowflake
-    else
-      _ -> :error
+    case Integer.parse(string) do
+      {snowflake, ""} when is_snowflake(snowflake) ->
+        snowflake
+
+      _ ->
+        :error
     end
   end
 

--- a/lib/structs/snowflake.ex
+++ b/lib/structs/snowflake.ex
@@ -189,7 +189,8 @@ defmodule Crux.Structs.Snowflake do
 
     ```
   """
-  @spec to_snowflake(String.t() | t()) :: t() | no_return()
+  @spec to_snowflake(t()) :: t()
+  @spec to_snowflake(String.t()) :: t() | no_return()
   @spec to_snowflake(nil) :: nil
   Util.since("0.2.1")
   def to_snowflake(nil), do: nil
@@ -202,6 +203,41 @@ defmodule Crux.Structs.Snowflake do
     string
     |> String.to_integer()
     |> to_snowflake()
+  end
+
+  @doc """
+    Converts a `t:String.t/0` to a `t:t/0` while allowing `t:t/0` to pass through.
+
+    Returns `:error` if the provided string is not an integer.
+
+    ```elixir
+    iex> Crux.Structs.Snowflake.parse("invalid")
+    :error
+
+    iex> Crux.Structs.Snowflake.parse(218348062828003328)
+    218348062828003328
+
+    # Fallbacks
+    iex> Crux.Structs.Snowflake.parse("218348062828003328")
+    218348062828003328
+
+    ```
+
+  """
+  @spec parse(t()) :: t()
+  @spec parse(String.t()) :: t() | :error
+  Util.since("0.2.1")
+
+  def parse(snowflake) when is_snowflake(snowflake) do
+    snowflake
+  end
+
+  def parse(string) when is_binary(string) do
+    with {snowflake, ""} when is_snowflake(snowflake) <- Integer.parse(string) do
+      snowflake
+    else
+      _ -> :error
+    end
   end
 
   # delegates

--- a/lib/structs/user.ex
+++ b/lib/structs/user.ex
@@ -5,7 +5,7 @@ defmodule Crux.Structs.User do
 
   @behaviour Crux.Structs
 
-  alias Crux.Structs.{Snowflake, User, Util}
+  alias Crux.Structs.{Snowflake, Member, Message, User, Util, VoiceState}
   require Util
 
   Util.modulesince("0.1.0")
@@ -27,6 +27,67 @@ defmodule Crux.Structs.User do
           id: Snowflake.t(),
           username: String.t()
         }
+
+  @typedoc """
+    All available types that can be resolved into a user id.
+  """
+  Util.typesince("0.2.1")
+
+  @type id_resolvable() ::
+          User.t() | Member.t() | Message.t() | VoiceState.t() | Snowflake.t() | String.t()
+
+  @doc """
+    Resolves the id of a `t:Crux.Structs.Guild.t/0`.
+
+  > Automatically invoked by `Crux.Structs.resolve_id/2`.
+
+    ```elixir
+    iex> %Crux.Structs.User{id: 218348062828003328}
+    ...> |> Crux.Structs.User.resolve_id()
+    218348062828003328
+
+    iex> %Crux.Structs.Member{user: 218348062828003328}
+    ...> |> Crux.Structs.User.resolve_id()
+    218348062828003328
+
+    iex> %Crux.Structs.Message{author: %Crux.Structs.User{id: 218348062828003328}}
+    ...> |> Crux.Structs.User.resolve_id()
+    218348062828003328
+
+    iex> %Crux.Structs.VoiceState{user_id: 218348062828003328}
+    ...> |> Crux.Structs.User.resolve_id()
+    218348062828003328
+
+    iex> 218348062828003328
+    ...> |> Crux.Structs.User.resolve_id()
+    218348062828003328
+
+    iex> "218348062828003328"
+    ...> |> Crux.Structs.User.resolve_id()
+    218348062828003328
+
+    ```
+  """
+  @spec resolve_id(id_resolvable()) :: Snowflake.t() | nil
+  Util.since("0.2.1")
+
+  def resolve_id(%User{id: id}) do
+    resolve_id(id)
+  end
+
+  def resolve_id(%Member{user: user}) do
+    resolve_id(user)
+  end
+
+  def resolve_id(%Message{author: author}) do
+    resolve_id(author)
+  end
+
+  def resolve_id(%VoiceState{user_id: user_id}) do
+    resolve_id(user_id)
+  end
+
+  def resolve_id(data), do: Crux.Structs.resolve_id(data)
 
   @doc """
     Creates a `t:Crux.Structs.User.t/0` struct from raw data.

--- a/lib/structs/user.ex
+++ b/lib/structs/user.ex
@@ -5,7 +5,8 @@ defmodule Crux.Structs.User do
 
   @behaviour Crux.Structs
 
-  alias Crux.Structs.{Snowflake, Member, Message, User, Util, VoiceState}
+  alias Crux.Structs
+  alias Crux.Structs.{Member, Message, Snowflake, User, Util, VoiceState}
   require Util
 
   Util.modulesince("0.1.0")
@@ -87,7 +88,7 @@ defmodule Crux.Structs.User do
     resolve_id(user_id)
   end
 
-  def resolve_id(data), do: Crux.Structs.resolve_id(data)
+  def resolve_id(data), do: Structs.resolve_id(data)
 
   @doc """
     Creates a `t:Crux.Structs.User.t/0` struct from raw data.

--- a/lib/structs/user.ex
+++ b/lib/structs/user.ex
@@ -6,7 +6,7 @@ defmodule Crux.Structs.User do
   @behaviour Crux.Structs
 
   alias Crux.Structs
-  alias Crux.Structs.{Member, Message, Snowflake, User, Util, VoiceState}
+  alias Crux.Structs.{Member, Message, Presence, Snowflake, User, Util, VoiceState}
   require Util
 
   Util.modulesince("0.1.0")
@@ -35,7 +35,13 @@ defmodule Crux.Structs.User do
   Util.typesince("0.2.1")
 
   @type id_resolvable() ::
-          User.t() | Member.t() | Message.t() | VoiceState.t() | Snowflake.t() | String.t()
+          User.t()
+          | Member.t()
+          | Message.t()
+          | Presence.t()
+          | VoiceState.t()
+          | Snowflake.t()
+          | String.t()
 
   @doc """
     Resolves the id of a `t:Crux.Structs.Guild.t/0`.
@@ -52,6 +58,10 @@ defmodule Crux.Structs.User do
     218348062828003328
 
     iex> %Crux.Structs.Message{author: %Crux.Structs.User{id: 218348062828003328}}
+    ...> |> Crux.Structs.User.resolve_id()
+    218348062828003328
+
+    iex> %Crux.Structs.Presence{user: 218348062828003328}
     ...> |> Crux.Structs.User.resolve_id()
     218348062828003328
 
@@ -82,6 +92,10 @@ defmodule Crux.Structs.User do
 
   def resolve_id(%Message{author: author}) do
     resolve_id(author)
+  end
+
+  def resolve_id(%Presence{user: user}) do
+    resolve_id(user)
   end
 
   def resolve_id(%VoiceState{user_id: user_id}) do

--- a/lib/structs/user.ex
+++ b/lib/structs/user.ex
@@ -102,7 +102,7 @@ defmodule Crux.Structs.User do
     resolve_id(user_id)
   end
 
-  def resolve_id(data), do: Structs.resolve_id(data)
+  def resolve_id(resolvable), do: Structs.resolve_id(resolvable)
 
   @doc """
     Creates a `t:Crux.Structs.User.t/0` struct from raw data.

--- a/lib/structs/voice_state.ex
+++ b/lib/structs/voice_state.ex
@@ -49,32 +49,8 @@ defmodule Crux.Structs.VoiceState do
 
   > Automatically invoked by `Crux.Structs.resolve_id/2`.
 
-    ```elixir
-    iex> %Crux.Structs.User{id: 218348062828003328}
-    ...> |> Crux.Structs.VoiceState.resolve_id()
-    218348062828003328
+    For examples see `Crux.Structs.User.resolve_id/1`.
 
-    iex> %Crux.Structs.Member{user: 218348062828003328}
-    ...> |> Crux.Structs.VoiceState.resolve_id()
-    218348062828003328
-
-    iex> %Crux.Structs.Message{author: %Crux.Structs.User{id: 218348062828003328}}
-    ...> |> Crux.Structs.VoiceState.resolve_id()
-    218348062828003328
-
-    iex> %Crux.Structs.VoiceState{user_id: 218348062828003328}
-    ...> |> Crux.Structs.VoiceState.resolve_id()
-    218348062828003328
-
-    iex> 218348062828003328
-    ...> |> Crux.Structs.VoiceState.resolve_id()
-    218348062828003328
-
-    iex> "218348062828003328"
-    ...> |> Crux.Structs.VoiceState.resolve_id()
-    218348062828003328
-
-    ```
   """
   @spec resolve_id(id_resolvable()) :: Snowflake.t() | nil
   Util.since("0.2.1")

--- a/lib/structs/voice_state.ex
+++ b/lib/structs/voice_state.ex
@@ -5,8 +5,9 @@ defmodule Crux.Structs.VoiceState do
 
   @behaviour Crux.Structs
 
-  alias Crux.Structs.{Snowflake, Util}
+  alias Crux.Structs.{Snowflake, User, Util}
   require Util
+  require Snowflake
 
   Util.modulesince("0.1.0")
 
@@ -36,6 +37,48 @@ defmodule Crux.Structs.VoiceState do
           self_mute: boolean(),
           suppress: boolean()
         }
+
+  @typedoc """
+    All available types that can be resolved into a user id.
+  """
+  Util.typesince("0.2.1")
+  @type id_resolvable() :: User.id_resolvable()
+
+  @doc """
+    Resolves the id of a `t:Crux.Structs.VoiceState.t/0`.
+
+  > Automatically invoked by `Crux.Structs.resolve_id/2`.
+
+    ```elixir
+    iex> %Crux.Structs.User{id: 218348062828003328}
+    ...> |> Crux.Structs.VoiceState.resolve_id()
+    218348062828003328
+
+    iex> %Crux.Structs.Member{user: 218348062828003328}
+    ...> |> Crux.Structs.VoiceState.resolve_id()
+    218348062828003328
+
+    iex> %Crux.Structs.Message{author: %Crux.Structs.User{id: 218348062828003328}}
+    ...> |> Crux.Structs.VoiceState.resolve_id()
+    218348062828003328
+
+    iex> %Crux.Structs.VoiceState{user_id: 218348062828003328}
+    ...> |> Crux.Structs.VoiceState.resolve_id()
+    218348062828003328
+
+    iex> 218348062828003328
+    ...> |> Crux.Structs.VoiceState.resolve_id()
+    218348062828003328
+
+    iex> "218348062828003328"
+    ...> |> Crux.Structs.VoiceState.resolve_id()
+    218348062828003328
+
+    ```
+  """
+  @spec resolve_id(id_resolvable()) :: Snowflake.t() | nil
+  Util.since("0.2.1")
+  defdelegate resolve_id(data), to: User
 
   @doc """
     Creates a `t:Crux.Structs.VoiceState.t/0` struct from raw data.

--- a/lib/structs/voice_state.ex
+++ b/lib/structs/voice_state.ex
@@ -7,7 +7,6 @@ defmodule Crux.Structs.VoiceState do
 
   alias Crux.Structs.{Snowflake, User, Util}
   require Util
-  require Snowflake
 
   Util.modulesince("0.1.0")
 
@@ -54,7 +53,7 @@ defmodule Crux.Structs.VoiceState do
   """
   @spec resolve_id(id_resolvable()) :: Snowflake.t() | nil
   Util.since("0.2.1")
-  defdelegate resolve_id(data), to: User
+  defdelegate resolve_id(resolvable), to: User
 
   @doc """
     Creates a `t:Crux.Structs.VoiceState.t/0` struct from raw data.

--- a/lib/structs/webhook.ex
+++ b/lib/structs/webhook.ex
@@ -35,6 +35,12 @@ defmodule Crux.Structs.Webhook do
           user: Snowflake.t() | nil
         }
 
+  @typedoc """
+    All available types that can be resolved into a webhook id.
+  """
+  Util.typesince("0.2.1")
+  @type id_resolvable() :: Webhook.t() | Snowflake.t() | String.t()
+
   @doc """
     Creates a `t:Crux.Structs.Webhook.t/0` struct from raw data.
 


### PR DESCRIPTION
This PR adds:
- `Snowflake.parse/1`, works similar to `to_snowflake`, but does not raise and returns `:error` instead
- `resolve_id/2` as function and `resolve_id/1` as optional behaviour function to `Crux.Structs`
- A custom `resolve_id/1` implementation for: `Channel`, `Emoji`, `Guild`, `Member`, `Presence`, `Reaction`, `User`, and `VoiceState`
- `resolve_position/1` for `Channel` and `Role`
- `resolve_target/1` for `Overwrite`