### PR TITLE
feat(VoiceState): add self_stream field

### DIFF
--- a/lib/structs/voice_state.ex
+++ b/lib/structs/voice_state.ex
@@ -19,6 +19,8 @@ defmodule Crux.Structs.VoiceState do
     mute: nil,
     self_deaf: nil,
     self_mute: nil,
+    # Only present if true
+    self_stream: false,
     # Can bots even do that?
     suppress: nil
   )
@@ -34,6 +36,7 @@ defmodule Crux.Structs.VoiceState do
           mute: boolean(),
           self_deaf: boolean(),
           self_mute: boolean(),
+          self_stream: boolean(),
           suppress: boolean()
         }
 


### PR DESCRIPTION
This PR adds the `self_stream` field to `VoiceState`.

`self_stream` indicates whether the user is making use of the `go live` feature.

See the documenting PR: https://github.com/discordapp/discord-api-docs/pull/1108