### PR TITLE
feat: add integration module and new audit log events

### DIFF
--- a/lib/structs/audit_log.ex
+++ b/lib/structs/audit_log.ex
@@ -5,7 +5,7 @@ defmodule Crux.Structs.AuditLog do
 
   @behaviour Crux.Structs
 
-  alias Crux.Structs.{AuditLog, AuditLogEntry, Snowflake, User, Util, Webhook}
+  alias Crux.Structs.{AuditLog, AuditLogEntry, Integration, Snowflake, User, Util, Webhook}
   require Util
 
   Util.modulesince("0.1.6")
@@ -13,6 +13,7 @@ defmodule Crux.Structs.AuditLog do
   defstruct(
     webhooks: %{},
     users: %{},
+    integrations: %{},
     audit_log_entries: %{}
   )
 
@@ -21,6 +22,7 @@ defmodule Crux.Structs.AuditLog do
   @type t :: %__MODULE__{
           webhooks: %{Snowflake.t() => Webhook.t()},
           users: %{Snowflake.t() => User.t()},
+          integrations: %{Snowflake.t() => map()},
           audit_log_entries: %{Snowflake.t() => AuditLogEntry.t()}
         }
 
@@ -44,6 +46,7 @@ defmodule Crux.Structs.AuditLog do
       |> Util.atomify()
       |> Map.update(:webhooks, [], &Util.raw_data_to_map(&1, Webhook))
       |> Map.update(:users, [], &Util.raw_data_to_map(&1, User))
+      |> Map.update(:integrations, [], &Util.raw_data_to_map(&1, Integration))
       |> Map.update(:audit_log_entries, [], &Util.raw_data_to_map(&1, AuditLogEntry))
 
     struct(__MODULE__, audit_log)

--- a/lib/structs/audit_log_entry.ex
+++ b/lib/structs/audit_log_entry.ex
@@ -24,6 +24,9 @@ defmodule Crux.Structs.AuditLogEntry do
     member_ban_remove: 23,
     member_update: 24,
     member_role_update: 25,
+    member_move: 26,
+    member_disconnect: 27,
+    bot_add: 28,
     role_create: 30,
     role_update: 31,
     role_delete: 32,
@@ -36,7 +39,13 @@ defmodule Crux.Structs.AuditLogEntry do
     emoji_create: 60,
     emoji_update: 61,
     emoji_delete: 62,
-    message_delete: 72
+    message_delete: 72,
+    message_bulk_delete: 73,
+    message_pin: 74,
+    message_unpin: 75,
+    integration_create: 80,
+    integration_update: 81,
+    integration_delete: 82
   }
 
   @typedoc """
@@ -58,6 +67,9 @@ defmodule Crux.Structs.AuditLogEntry do
           | :member_ban_remove
           | :member_update
           | :member_role_update
+          | :member_move
+          | :member_disconnect
+          | :bot_add
           | :role_create
           | :role_update
           | :role_delete
@@ -71,6 +83,12 @@ defmodule Crux.Structs.AuditLogEntry do
           | :emoji_update
           | :emoji_delete
           | :message_delete
+          | :message_bulk_delete
+          | :message_pin
+          | :message_unpin
+          | :integration_create
+          | :integration_update
+          | :integration_delete
 
   @audit_log_events_key Map.new(@audit_log_events, fn {k, v} -> {v, k} end)
 

--- a/lib/structs/integration.ex
+++ b/lib/structs/integration.ex
@@ -1,0 +1,61 @@
+defmodule Crux.Structs.Integration do
+  @moduledoc """
+    Represents a Discord [Integration Object](https://discordapp.com/developers/docs/resources/guild#integration-object).
+  """
+
+  @behaviour Crux.Structs
+
+  alias Crux.Structs.{Snowflake, Util}
+  require Util
+
+  Util.modulesince("0.2.2")
+
+  defstruct(
+    id: nil,
+    name: nil,
+    type: nil,
+    enabled: nil,
+    syncing: nil,
+    role_id: nil,
+    expire_behavior: nil,
+    expire_grace_period: nil,
+    user: nil,
+    account: nil,
+    synced_at: nil
+  )
+
+  Util.typesince("0.2.2")
+
+  @type t :: %__MODULE__{
+          id: Snowflake.t(),
+          name: String.t(),
+          type: String.t(),
+          enabled: boolean(),
+          syncing: boolean(),
+          role_id: Snowflake.t(),
+          expire_behavior: integer(),
+          expire_grace_period: integer(),
+          user: Snowflake.t(),
+          account: map(),
+          synced_at: String.t()
+        }
+
+  @doc """
+    Creates a `t:Crux.Structs.Integration.t/0` struct from raw data.
+
+  > Automatically invoked by `Crux.Structs.create/2`.
+  """
+  @spec create(data :: map()) :: t()
+  Util.since("0.2.2")
+
+  def create(data) do
+    integration =
+      data
+      |> Util.atomify()
+      |> Map.update(:id, nil, &Snowflake.to_snowflake/1)
+      |> Map.update(:role_id, nil, &Snowflake.to_snowflake/1)
+      |> Map.update(:user, nil, Util.map_to_id())
+
+    struct(__MODULE__, integration)
+  end
+end

--- a/lib/structs/integration.ex
+++ b/lib/structs/integration.ex
@@ -55,6 +55,9 @@ defmodule Crux.Structs.Integration do
       |> Map.update(:id, nil, &Snowflake.to_snowflake/1)
       |> Map.update(:role_id, nil, &Snowflake.to_snowflake/1)
       |> Map.update(:user, nil, Util.map_to_id())
+      |> Map.update(:account, nil, fn account ->
+        Map.update(account, :id, nil, &Snowflake.to_snowflake/1)
+      end)
 
     struct(__MODULE__, integration)
   end

--- a/test/structs/integration_test.exs
+++ b/test/structs/integration_test.exs
@@ -1,0 +1,48 @@
+defmodule Crux.Structs.IntegrationTest do
+  use ExUnit.Case, async: true
+  doctest Crux.Structs.Integration
+
+  test "create" do
+    # Never seen a real integration object, this is just one reconstructed from the docs
+    integration =
+      %{
+        "id" => "647006042328268800",
+        "name" => "TestName",
+        "type" => "youtube",
+        "enabled" => true,
+        "syncing" => true,
+        "role_id" => "647006142660214785",
+        "expire_behavior" => 0,
+        "expire_grace_period" => 0,
+        "user" => %{
+          "avatar" => "646a356e237350bf8b8dfde15667dfc4",
+          "discriminator" => "0001",
+          "id" => "218348062828003328",
+          "username" => "space"
+        },
+        "account" => %{
+          "id" => "647006500681809922",
+          "name" => "AccountName"
+        },
+        "synced_at" => "ISO8601 timestamp"
+      }
+      |> Crux.Structs.create(Crux.Structs.Integration)
+
+    assert integration == %Crux.Structs.Integration{
+             id: 647_006_042_328_268_800,
+             name: "TestName",
+             type: "youtube",
+             enabled: true,
+             syncing: true,
+             role_id: 647_006_142_660_214_785,
+             expire_behavior: 0,
+             expire_grace_period: 0,
+             user: 218_348_062_828_003_328,
+             account: %{
+               id: 647_006_500_681_809_922,
+               name: "AccountName"
+             },
+             synced_at: "ISO8601 timestamp"
+           }
+  end
+end


### PR DESCRIPTION
This PR adds new audit log event types and the now more relevant `Integration` object as its own module.

Relevant PR on Discord's documentation repository: https://github.com/discordapp/discord-api-docs/pull/1191