### PR TITLE
feat(VoiceRegion): add voice region module and struct

### DIFF
--- a/lib/structs/voice_region.ex
+++ b/lib/structs/voice_region.ex
@@ -1,0 +1,32 @@
+defmodule Crux.Structs.VoiceRegion do
+  @moduledoc """
+    Represents a Discord [Voice Region Object](https://discordapp.com/developers/docs/resources/voice#voice-region-object).
+  """
+
+  @behaviour Crux.Structs
+
+  alias Crux.Structs.{Snowflake, Util, VoiceRegion}
+  require Util
+
+  Util.modulesince("0.2.3")
+
+  defstruct(
+    id: nil,
+    name: nil,
+    vip: nil,
+    optimal: nil,
+    deprecated: nil,
+    custom: nil
+  )
+
+  Util.typesince("0.2.3")
+
+  @type t :: %__MODULE__{
+          id: String.t(),
+          name: String.t(),
+          vip: boolean(),
+          optimal: boolean(),
+          deprecated: boolean(),
+          custom: boolean()
+        }
+end

--- a/lib/structs/voice_region.ex
+++ b/lib/structs/voice_region.ex
@@ -5,7 +5,7 @@ defmodule Crux.Structs.VoiceRegion do
 
   @behaviour Crux.Structs
 
-  alias Crux.Structs.{Snowflake, Util, VoiceRegion}
+  alias Crux.Structs.Util
   require Util
 
   Util.modulesince("0.2.3")


### PR DESCRIPTION
This PR adds the [Voice Region Object](https://discordapp.com/developers/docs/resources/voice#voice-region-object) as module and struct.