### PR TITLE
feat: add GuildPreview struct

### DIFF
--- a/lib/structs/guild_preview.ex
+++ b/lib/structs/guild_preview.ex
@@ -1,0 +1,64 @@
+defmodule Crux.Structs.GuildPreview do
+  @moduledoc """
+  Represents a Discord [Guild Preview Object](TODO)
+
+  """
+
+  @behaviour Crux.Structs
+
+  alias Crux.Structs.{Emoji, Snowflake, Util}
+  require Util
+
+  Util.modulesince("0.2.3")
+
+  defstruct(
+    id: nil,
+    name: nil,
+    icon: nil,
+    splash: nil,
+    discovery_splash: nil,
+    emojis: %{},
+    features: [],
+    approximate_member_count: nil,
+    approximate_presence_count: nil,
+    description: nil
+  )
+
+  Util.typesince("0.2.3")
+
+  @type t :: %__MODULE__{
+          id: Snowflake.t(),
+          name: String.t(),
+          icon: String.t() | nil,
+          splash: String.t() | nil,
+          discovery_splash: String.t() | nil,
+          emojis: %{required(Snowflake.t()) => Emoji.t()},
+          features: [String.t()],
+          approximate_member_count: non_neg_integer(),
+          approximate_presence_count: non_neg_integer(),
+          description: String.t()
+        }
+
+  @doc """
+  Creates a `t:Crux.Structs.GuildPreview.t/0` struct from raw data.
+
+  > Automatically invoked by `Crux.Structs.create/2`.
+  """
+  @spec create(data :: map()) :: t()
+  Util.since("0.1.0")
+
+  def create(data) do
+    data =
+      data
+      |> Util.atomify()
+      |> Map.update!(:id, &Snowflake.to_snowflake/1)
+      |> Map.update(:emojis, %{}, &Util.raw_data_to_map(&1, Emoji))
+
+    struct(__MODULE__, data)
+  end
+
+  defimpl String.Chars, for: Crux.Structs.GuildPreview do
+    @spec to_string(Crux.Structs.GuildPreview.t()) :: String.t()
+    def to_string(%Crux.Structs.GuildPreview{name: name}), do: name
+  end
+end

--- a/test/structs/guild_preview_test.exs
+++ b/test/structs/guild_preview_test.exs
@@ -1,0 +1,83 @@
+defmodule Crux.Structs.GuildPreviewTest do
+  use ExUnit.Case, async: true
+  doctest Crux.Structs.Guild
+
+  test "create" do
+    guild_preview =
+      %{
+        id: "197038439483310086",
+        name: "Discord Testers",
+        icon: "f64c482b807da4f539cff778d174971c",
+        splash: nil,
+        discovery_splash: nil,
+        emojis: [
+          %{
+            name: "name",
+            roles: ["197038439483310086"],
+            id: "197038439483310086",
+            require_colons: true,
+            managed: false,
+            animated: false,
+            available: true
+          }
+        ],
+        features: [
+          "DISCOVERABLE",
+          "VANITY_URL",
+          "ANIMATED_ICON",
+          "INVITE_SPLASH",
+          "NEWS",
+          "PUBLIC",
+          "BANNER",
+          "VERIFIED",
+          "MORE_EMOJI"
+        ],
+        approximate_member_count: 60814,
+        approximate_presence_count: 20034,
+        description: "The official place to report Discord Bugs!"
+      }
+      |> Crux.Structs.create(Crux.Structs.GuildPreview)
+
+    assert guild_preview == %Crux.Structs.GuildPreview{
+             id: 197_038_439_483_310_086,
+             name: "Discord Testers",
+             icon: "f64c482b807da4f539cff778d174971c",
+             splash: nil,
+             discovery_splash: nil,
+             emojis: %{
+               197_038_439_483_310_086 => %Crux.Structs.Emoji{
+                 name: "name",
+                 roles: MapSet.new([197_038_439_483_310_086]),
+                 id: 197_038_439_483_310_086,
+                 require_colons: true,
+                 managed: false,
+                 animated: false
+                 #  TODO: Add this
+                 #  available: true
+               }
+             },
+             features: [
+               "DISCOVERABLE",
+               "VANITY_URL",
+               "ANIMATED_ICON",
+               "INVITE_SPLASH",
+               "NEWS",
+               "PUBLIC",
+               "BANNER",
+               "VERIFIED",
+               "MORE_EMOJI"
+             ],
+             approximate_member_count: 60814,
+             approximate_presence_count: 20034,
+             description: "The official place to report Discord Bugs!"
+           }
+  end
+
+  test "to_string returns name" do
+    stringified =
+      %Crux.Structs.GuildPreview{name: "a cool name"}
+      |> to_string()
+
+    assert stringified == "a cool name"
+  end
+end


### PR DESCRIPTION
This PR adds the `GuildPreview` module and struct.

Relevant PR for the upstream documentation: https://github.com/discordapp/discord-api-docs/pull/1405