### PR TITLE
feat(User): add public_flags

### DIFF
--- a/lib/structs/user.ex
+++ b/lib/structs/user.ex
@@ -16,7 +16,8 @@ defmodule Crux.Structs.User do
     bot: false,
     discriminator: nil,
     id: nil,
-    username: nil
+    username: nil,
+    public_flags: nil
   )
 
   Util.typesince("0.1.0")
@@ -26,7 +27,8 @@ defmodule Crux.Structs.User do
           bot: boolean(),
           discriminator: String.t(),
           id: Snowflake.t(),
-          username: String.t()
+          username: String.t(),
+          public_flags: integer()
         }
 
   @typedoc """


### PR DESCRIPTION
This PR adds `public_flags` to `Crux.Structs.User`.

These flags contain an undocumented subset of user flags. (e.g. discord_employee, discord_partner, )

Relevant upstream PR: https://github.com/discord/discord-api-docs/pull/1490