### PR TITLE
feat: add BitField behaviour and modules using it

### DIFF
--- a/lib/structs/bit_field.ex
+++ b/lib/structs/bit_field.ex
@@ -99,23 +99,20 @@ defmodule Crux.Structs.BitField do
       use Bitwise
 
       @flags unquote(flags)
-
       @doc """
       Get a map of `t:name/0`s and their corresponding bit values.
       """
-      @spec flags :: %{required(name()) => non_neg_integer()}
+      @spec flags() :: %{required(name()) => non_neg_integer()}
       def flags(), do: @flags
 
-      @names @flags |> Map.keys()
-
+      @names Map.keys(@flags)
       @doc """
       Get a list of all available `t:name/0`s.
       """
       @spec names() :: [name()]
       def names(), do: @names
 
-      @all @flags |> Enum.reduce(0, fn {_name, bit}, acc -> bit ||| acc end)
-
+      @all Enum.reduce(@flags, 0, fn {_name, bit}, acc -> bit ||| acc end)
       @doc """
       Get an integer representing all available bits set.
       """

--- a/lib/structs/bit_field.ex
+++ b/lib/structs/bit_field.ex
@@ -1,0 +1,252 @@
+defmodule Crux.Structs.BitField do
+  @moduledoc """
+  Custom non discord api behaviour to help with bitfields of all kind.
+  """
+
+  alias Crux.Structs.Util
+  require Util
+
+  Util.modulesince("0.2.3")
+
+  @typedoc """
+  The name of a bit flag.
+  """
+  Util.typesince("0.2.3")
+  @type name :: atom()
+
+  @doc """
+  Get a map of `t:name/0`s and their corresponding bit values.
+  """
+  Util.since("0.2.3")
+  @callback flags() :: %{required(name()) => non_neg_integer()}
+
+  @doc """
+  Get a list of all available `t:name/0`s.
+  """
+  Util.since("0.2.3")
+  @callback names() :: [name()]
+
+  @doc """
+  Get an integer representing all available bits set.
+  """
+  Util.since("0.2.3")
+  @callback all() :: non_neg_integer()
+
+  @typedoc """
+  All valid types that can be directly resolved into a bitfield.
+  """
+  Util.typesince("0.2.3")
+  @type resolvable() :: t() | non_neg_integer() | name() | [resolvable()]
+
+  @typedoc """
+  Represents a struct of a module implementing the `Crux.Structs.BitField` behaviour.
+  """
+  Util.typesince("0.2.3")
+  @type t :: struct()
+
+  @doc """
+  Create a new `t:t/0` from a `t:resolvable/0`.
+  """
+  Util.since("0.2.3")
+  @callback new(resolvable()) :: t()
+
+  @doc """
+  Resolve a `t:resolvable/0` into a bitfield.
+  """
+  Util.since("0.2.3")
+  @callback resolve(resolvable()) :: non_neg_integer()
+
+  @doc """
+  Serialize a `t:resolvable/0` into a map representing bit flag names to whether they are set.
+  """
+  Util.since("0.2.3")
+  @callback to_map(resolvable()) :: %{required(name()) => boolean()}
+
+  @doc """
+  Serialize a `t:resolvable/0` into a list of set bit flag names.
+  """
+  Util.since("0.2.3")
+  @callback to_list(resolvable()) :: [name()]
+
+  @doc """
+  Add all set bits of `to_add` to `base`.
+  """
+  Util.since("0.2.3")
+  @callback add(base :: resolvable(), to_add :: resolvable()) :: t()
+
+  @doc """
+  Remove all set bits of `to_remove` from `base`.
+  """
+  Util.since("0.2.3")
+  @callback remove(base :: resolvable(), to_remove :: resolvable()) :: t()
+
+  @doc """
+  Check whether the `t:resolvable/0` you `have` has everything set you `want`.
+  """
+  Util.since("0.2.3")
+  @callback has(have :: resolvable(), want :: resolvable()) :: boolean()
+
+  @doc """
+  Return a `t:t/0` of all bits you `want` but not `have`.
+  """
+  Util.since("0.2.3")
+  @callback missing(have :: resolvable(), want :: resolvable()) :: t()
+
+  defmacro __using__(flags) do
+    quote location: :keep do
+      @behaviour Crux.Structs.BitField
+
+      use Bitwise
+
+      @flags unquote(flags)
+
+      @doc """
+      Get a map of `t:name/0`s and their corresponding bit values.
+      """
+      @spec flags :: %{required(name()) => non_neg_integer()}
+      def flags(), do: @flags
+
+      @names @flags |> Map.keys()
+
+      @doc """
+      Get a list of all available `t:name/0`s.
+      """
+      @spec names() :: [name()]
+      def names(), do: @names
+
+      @all @flags |> Enum.reduce(0, fn {_name, bit}, acc -> bit ||| acc end)
+
+      @doc """
+      Get an integer representing all available bits set.
+      """
+      @spec all() :: non_neg_integer()
+      def all(), do: @all
+
+      @typedoc """
+      All valid types that can be directly resolved into a bitfield.
+      """
+      @type resolvable() :: t() | raw() | name() | [resolvable()]
+
+      defstruct bitfield: 0
+
+      @type t :: %__MODULE__{
+              bitfield: non_neg_integer()
+            }
+
+      @typedoc """
+      Raw bitfield that can be used as a `t:resolvable/0`.
+      """
+      @type raw :: non_neg_integer()
+
+      @doc """
+      Create a new `t:t/0` from a `t:resolvable/0`.
+      """
+      @spec new(resolvable()) :: t()
+      def new(resolvable \\ 0), do: %__MODULE__{bitfield: resolve(resolvable)}
+
+      @doc """
+      Resolve a `t:resolvable/0` into a bitfield.
+      """
+      @spec resolve(resolvable()) :: non_neg_integer()
+      def resolve(resolvable)
+
+      def resolve(%__MODULE__{bitfield: bitfield}), do: bitfield
+
+      def resolve(resolvable) when is_integer(resolvable) and resolvable >= 0 do
+        resolvable
+      end
+
+      def resolve(resolvable) when resolvable in @names do
+        Map.get(@flags, resolvable)
+      end
+
+      def resolve(resolvable) when is_list(resolvable) do
+        Enum.reduce(resolvable, 0, &(resolve(&1) ||| &2))
+      end
+
+      def resolve(resolvable) do
+        raise ArgumentError, """
+        Expected a name atom, a non negative integer, or a list of them.
+
+        Received:
+        #{inspect(resolvable)}
+        """
+      end
+
+      @doc """
+      Serialize a `t:resolvable/0` into a map representing bit flag names to whether they are set.
+      """
+      @spec to_map(resolvable()) :: %{required(name()) => boolean()}
+      def to_map(resolvable) do
+        bitfield = resolve(resolvable)
+
+        Map.new(@names, &{&1, has(bitfield, &1)})
+      end
+
+      @doc """
+      Serialize a `t:resolvable/0` into a list of set bit flag names.
+      """
+      @spec to_list(resolvable()) :: [name()]
+      def to_list(resolvable) do
+        resolvable = resolve(resolvable)
+
+        Enum.reduce(@flags, [], fn {name, val}, acc ->
+          if has(resolvable, val), do: [name | acc], else: acc
+        end)
+      end
+
+      @doc """
+      Add all set bits of `to_add` to `base`.
+      """
+      @spec add(base :: resolvable(), to_add :: resolvable()) :: t()
+      def add(base, to_add) do
+        to_add = resolve(to_add)
+
+        base
+        |> resolve()
+        |> bor(to_add)
+        |> new()
+      end
+
+      @doc """
+      Remove all set bits of `to_remove` from `base`.
+      """
+      @spec remove(base :: resolvable(), to_remove :: resolvable()) :: t()
+      def remove(base, to_remove) do
+        to_remove = to_remove |> resolve() |> bnot()
+
+        base
+        |> resolve()
+        |> band(to_remove)
+        |> new()
+      end
+
+      @doc """
+      Check whether the `t:resolvable/0` you `have` has everything set you `want`.
+      """
+      @spec has(
+              have :: resolvable(),
+              want :: resolvable()
+            ) :: boolean()
+      def has(have, want) do
+        have = resolve(have)
+        want = resolve(want)
+
+        (have &&& want) == want
+      end
+
+      @doc """
+      Return a `t:t/0` of all bits you `want` but not `have`.
+      """
+      @spec missing(resolvable(), resolvable()) :: t()
+      def missing(have, want) do
+        have = resolve(have)
+        want = resolve(want)
+
+        want
+        |> band(~~~have)
+        |> new()
+      end
+    end
+  end
+end

--- a/lib/structs/guild.ex
+++ b/lib/structs/guild.ex
@@ -99,7 +99,7 @@ defmodule Crux.Structs.Guild do
           roles: %{optional(Snowflake.t()) => Role.t()},
           rules_channel_id: Snowflake.t() | nil,
           splash: String.t() | nil,
-          system_channel_flags: non_neg_integer(),
+          system_channel_flags: Guild.SystemChannelFlags.raw(),
           system_channel_id: Snowflake.t() | nil,
           unavailable: boolean(),
           vanity_url_code: String.t() | nil,

--- a/lib/structs/guild/system_channel_flags.ex
+++ b/lib/structs/guild/system_channel_flags.ex
@@ -7,10 +7,6 @@ defmodule Crux.Structs.Guild.SystemChannelFlags do
   """
 
   alias Crux.Structs.Util
-  require Util
-
-  Util.modulesince("0.2.3")
-
   use Bitwise
 
   flags = %{
@@ -19,6 +15,10 @@ defmodule Crux.Structs.Guild.SystemChannelFlags do
   }
 
   use Crux.Structs.BitField, flags
+
+  require Util
+
+  Util.modulesince("0.2.3")
 
   @typedoc """
   Union type of all valid system channel flags.

--- a/lib/structs/guild/system_channel_flags.ex
+++ b/lib/structs/guild/system_channel_flags.ex
@@ -1,0 +1,28 @@
+defmodule Crux.Structs.Guild.SystemChannelFlags do
+  @moduledoc """
+  Custom non discord API struct helping with the usage of system channel flags.
+
+  Discord is using flags in an "inverted" way here to allow all new types to be enabled by default.
+  Therefore all set flags are actually disabled (as their names suggest).
+  """
+
+  alias Crux.Structs.Util
+  require Util
+
+  Util.modulesince("0.2.3")
+
+  use Bitwise
+
+  flags = %{
+    suppress_join_notifications: 1 <<< 0,
+    suppress_preimum_subscriptions: 1 <<< 0
+  }
+
+  use Crux.Structs.BitField, flags
+
+  @typedoc """
+  Union type of all valid system channel flags.
+  """
+  Util.typesince("0.2.3")
+  @type name :: :suppress_join_notifications | :suppress_preimum_subscriptions
+end

--- a/lib/structs/message.ex
+++ b/lib/structs/message.ex
@@ -91,7 +91,7 @@ defmodule Crux.Structs.Message do
           content: String.t(),
           edited_timestamp: String.t(),
           embeds: [Embed.t()],
-          flags: non_neg_integer(),
+          flags: Message.Flags.raw(),
           guild_id: Snowflake.t() | nil,
           id: Snowflake.t(),
           member: Member.t() | nil,

--- a/lib/structs/message/flags.ex
+++ b/lib/structs/message/flags.ex
@@ -6,9 +6,6 @@ defmodule Crux.Structs.Message.Flags do
   """
 
   alias Crux.Structs.Util
-  require Util
-  Util.modulesince("0.2.3")
-
   use Bitwise
 
   flags = %{
@@ -20,6 +17,9 @@ defmodule Crux.Structs.Message.Flags do
   }
 
   use Crux.Structs.BitField, flags
+
+  require Util
+  Util.modulesince("0.2.3")
 
   @typedoc """
   Union type of all valid message flags.

--- a/lib/structs/message/flags.ex
+++ b/lib/structs/message/flags.ex
@@ -1,0 +1,35 @@
+defmodule Crux.Structs.Message.Flags do
+  @moduledoc """
+  Custom non discord API struct helping with the usage of message flags.
+
+  Currently it's only possible to edit the `suppress_embeds` flag.
+  """
+
+  alias Crux.Structs.Util
+  require Util
+  Util.modulesince("0.2.3")
+
+  use Bitwise
+
+  flags = %{
+    crossposted: 1 <<< 0,
+    is_crosspost: 1 <<< 1,
+    suppress_embeds: 1 <<< 2,
+    source_message_deleted: 1 <<< 3,
+    urgent: 1 <<< 4
+  }
+
+  use Crux.Structs.BitField, flags
+
+  @typedoc """
+  Union type of all valid message flags.
+  """
+  Util.typesince("0.2.3")
+
+  @type name ::
+          :crossposted
+          | :is_crosspost
+          | :suppress_embeds
+          | :source_message_deleted
+          | :urgent
+end

--- a/lib/structs/permissions.ex
+++ b/lib/structs/permissions.ex
@@ -7,9 +7,6 @@ defmodule Crux.Structs.Permissions do
 
   alias Crux.Structs
   alias Crux.Structs.Util
-  require Util
-
-  Util.modulesince("0.1.3")
 
   use Bitwise
 
@@ -48,6 +45,10 @@ defmodule Crux.Structs.Permissions do
   }
 
   use Crux.Structs.BitField, permissions
+
+  require Util
+
+  Util.modulesince("0.1.3")
 
   @typedoc """
     Union type of all valid permission name atoms.

--- a/lib/structs/permissions.ex
+++ b/lib/structs/permissions.ex
@@ -7,12 +7,13 @@ defmodule Crux.Structs.Permissions do
 
   alias Crux.Structs
   alias Crux.Structs.Util
-  use Bitwise
   require Util
 
   Util.modulesince("0.1.3")
 
-  @permissions %{
+  use Bitwise
+
+  permissions = %{
     create_instant_invite: 1 <<< 0,
     kick_members: 1 <<< 1,
     ban_members: 1 <<< 2,
@@ -45,28 +46,8 @@ defmodule Crux.Structs.Permissions do
     manage_webhooks: 1 <<< 29,
     manage_emojis: 1 <<< 30
   }
-  @doc """
-    Returns a map of all permissions.
-  """
-  @spec flags() :: %{name() => non_neg_integer()}
-  Util.since("0.2.0")
-  def flags(), do: @permissions
 
-  @names Map.keys(@permissions)
-  @doc """
-  Returns a list of all permission keys.
-  """
-  @spec names() :: [name()]
-  Util.since("0.2.0")
-  def names(), do: @names
-
-  @all @permissions |> Map.values() |> Enum.reduce(&|||/2)
-  @doc """
-    Returns the integer value of all permissions summed up.
-  """
-  @spec all() :: pos_integer()
-  Util.since("0.2.0")
-  def all(), do: @all
+  use Crux.Structs.BitField, permissions
 
   @typedoc """
     Union type of all valid permission name atoms.
@@ -105,250 +86,6 @@ defmodule Crux.Structs.Permissions do
           | :manage_roles
           | :manage_webhooks
           | :manage_emojis
-
-  defstruct(bitfield: 0)
-
-  @typedoc """
-    All valid types which can be directly resolved into a permissions bitfield.
-  """
-  Util.typesince("0.2.0")
-  @type resolvable :: t() | non_neg_integer() | name() | [resolvable()]
-
-  @typedoc """
-    Represents a `t:Crux.Structs.Permissions.t/0`.
-
-    * `:bitfield`: The raw bitfield of permission flags.
-  """
-  Util.typesince("0.1.3")
-
-  @type t :: %__MODULE__{
-          bitfield: non_neg_integer()
-        }
-
-  @doc """
-    Creates a new `t:Crux.Structs.Permissions.t/0` from a valid `t:resolvable/0`.
-  """
-  @spec new(permissions :: resolvable()) :: t()
-  Util.since("0.1.3")
-  def new(permissions \\ 0), do: %__MODULE__{bitfield: resolve(permissions)}
-
-  @doc ~S"""
-    Resolves a `t:resolvable/0` into a bitfield representing the set permissions.
-
-  ## Examples
-    ```elixir
-  # A single bitflag
-  iex> 0x8
-  ...> |> Crux.Structs.Permissions.resolve()
-  0x8
-
-  # A single name
-  iex> :administrator
-  ...> |> Crux.Structs.Permissions.resolve()
-  0x8
-
-  # A list of bitflags
-  iex> [0x8, 0x4]
-  ...> |> Crux.Structs.Permissions.resolve()
-  0xC
-
-  # A list of names
-  iex> [:administrator, :ban_members]
-  ...> |> Crux.Structs.Permissions.resolve()
-  0xC
-
-  # A mixture of both
-  iex> [:manage_roles, 0x400, 0x800, :add_reactions]
-  ...> |> Crux.Structs.Permissions.resolve()
-  0x10000C40
-
-  # An empty list
-  iex> []
-  ...> |> Crux.Structs.Permissions.resolve()
-  0x0
-
-    ```
-  """
-  @spec resolve(permissions :: resolvable()) :: non_neg_integer()
-  Util.since("0.1.3")
-  def resolve(permissions)
-
-  def resolve(%__MODULE__{bitfield: bitfield}), do: bitfield
-
-  def resolve(permissions) when is_integer(permissions) and permissions >= 0 do
-    Enum.reduce(@permissions, 0, fn {_name, value}, acc ->
-      if (permissions &&& value) == value, do: acc ||| value, else: acc
-    end)
-  end
-
-  def resolve(permissions) when permissions in @names do
-    Map.get(@permissions, permissions)
-  end
-
-  def resolve(permissions) when is_list(permissions) do
-    permissions
-    |> Enum.map(&resolve/1)
-    |> Enum.reduce(0, &|||/2)
-  end
-
-  def resolve(permissions) do
-    raise """
-    Expected a name atom, a non negative integer, or a list of them.
-
-    Received:
-    #{inspect(permissions)}
-    """
-  end
-
-  @doc ~S"""
-    Serializes permissions into a map keyed by `t:name/0` with a boolean indicating whether the permission is set.
-  """
-  @spec to_map(permissions :: resolvable()) :: %{name() => boolean()}
-  Util.since("0.1.3")
-
-  def to_map(permissions) do
-    permissions = resolve(permissions)
-
-    Map.new(@names, &{&1, has(permissions, &1)})
-  end
-
-  @doc ~S"""
-    Serializes permissions into a list of set `t:name/0`s.
-
-  ## Examples
-    ```elixir
-  iex> 0x30
-  ...> |> Crux.Structs.Permissions.to_list()
-  [:manage_guild, :manage_channels]
-
-    ```
-  """
-  @spec to_list(permissions :: resolvable()) :: [name()]
-  Util.since("0.1.3")
-
-  def to_list(permissions) do
-    permissions = resolve(permissions)
-
-    Enum.reduce(@permissions, [], fn {name, val}, acc ->
-      if has(permissions, val), do: [name | acc], else: acc
-    end)
-  end
-
-  @doc ~S"""
-    Adds permissions to the base permissions.
-
-  ## Examples
-    ```elixir
-  iex> :administrator
-  ...> |> Crux.Structs.Permissions.add(:manage_guild)
-  %Crux.Structs.Permissions{bitfield: 0x28}
-
-    ```
-  """
-  @spec add(base :: resolvable(), to_add :: resolvable()) :: t()
-  Util.since("0.1.3")
-
-  def add(base, to_add) do
-    to_add = resolve(to_add)
-
-    base
-    |> resolve()
-    |> bor(to_add)
-    |> new()
-  end
-
-  @doc ~S"""
-    Removes permissions from the base permissions
-
-  ## Examples
-    ```elixir
-  iex> [0x8, 0x10, 0x20]
-  ...> |> Crux.Structs.Permissions.remove([0x10, 0x20])
-  %Crux.Structs.Permissions{bitfield: 0x8}
-
-    ```
-  """
-  @spec remove(base :: resolvable(), to_remove :: resolvable()) :: t()
-  Util.since("0.1.3")
-
-  def remove(base, to_remove) do
-    to_remove = to_remove |> resolve() |> bnot()
-
-    base
-    |> resolve()
-    |> band(to_remove)
-    |> new()
-  end
-
-  @doc ~S"""
-    Check whether the second permissions are all present in the first.
-
-  ## Examples
-    ```elixir
-  # Administrator won't grant any other permissions
-  iex> Crux.Structs.Permissions.has(0x8, Crux.Structs.Permissions.all())
-  false
-
-  # Resolving a list of `permissions_name`s
-  iex> Crux.Structs.Permissions.has([:send_messages, :view_channel, :read_message_history], [:send_messages, :view_channel])
-  true
-
-  # Resolving different types of `permissions`s
-  iex> Crux.Structs.Permissions.has(:administrator, 0x8)
-  true
-
-  # In different order
-  iex> Crux.Structs.Permissions.has(0x8, :administrator)
-  true
-
-    ```
-  """
-  @spec has(
-          have :: resolvable(),
-          want :: resolvable()
-        ) :: boolean()
-  Util.since("0.1.3")
-
-  def has(have, want) do
-    have = resolve(have)
-    want = resolve(want)
-
-    (have &&& want) == want
-  end
-
-  @doc ~S"""
-    Similar to `has/2` but returns a `t:Crux.Structs.Permissions.t/0` of the missing permissions.
-
-  ## Examples
-    ```elixir
-  iex> Crux.Structs.Permissions.missing([:send_messages, :view_channel], [:send_messages, :view_channel, :embed_links])
-  %Crux.Structs.Permissions{bitfield: 0x4000}
-
-  # Administrator won't implicilty grant other permissions
-  iex> Crux.Structs.Permissions.missing([:administrator], [:send_messages])
-  %Crux.Structs.Permissions{bitfield: 0x800}
-
-  # Everything set
-  iex> Crux.Structs.Permissions.missing([:kick_members, :ban_members, :view_audit_log], [:kick_members, :ban_members])
-  %Crux.Structs.Permissions{bitfield: 0}
-
-  # No permissions
-  iex> Crux.Structs.Permissions.missing([:send_messages, :view_channel], [])
-  %Crux.Structs.Permissions{bitfield: 0}
-
-    ```
-  """
-  @spec missing(resolvable(), resolvable()) :: t()
-  Util.since("0.2.0")
-
-  def missing(have, want) do
-    have = resolve(have)
-    want = resolve(want)
-
-    want
-    |> band(~~~have)
-    |> new()
-  end
 
   @doc """
     Resolves permissions for a user in a guild, optionally including channel permission overwrites.

--- a/lib/structs/presence.ex
+++ b/lib/structs/presence.ex
@@ -104,8 +104,11 @@ defmodule Crux.Structs.Presence do
     |> create_activity()
   end
 
-  defp create_activity(%{emoji: emoji} = activity)
-       when not is_nil(emoji) do
+  defp create_activity(%{emoji: nil} = activity) do
+    activity
+  end
+
+  defp create_activity(%{emoji: _emoji} = activity) do
     Map.update!(activity, :emoji, &Structs.create(&1, Emoji))
   end
 

--- a/lib/structs/presence.ex
+++ b/lib/structs/presence.ex
@@ -8,7 +8,9 @@ defmodule Crux.Structs.Presence do
 
   @behaviour Crux.Structs
 
-  alias Crux.Structs.{Snowflake, User, Util}
+  alias Crux.Structs
+  alias Crux.Structs.{Emoji, Presence, Snowflake, User, Util}
+  require Snowflake
   require Util
 
   Util.modulesince("0.1.0")
@@ -23,6 +25,28 @@ defmodule Crux.Structs.Presence do
     client_status: %{}
   )
 
+  @typedoc """
+  Represents an [Activity Structure](https://discordapp.com/developers/docs/topics/gateway#activity-object-activity-structure).
+  """
+  Util.typesince("0.2.3")
+
+  @type activity :: %{
+          required(:name) => String.t(),
+          required(:type) => integer(),
+          optional(:url) => nil | String.t(),
+          required(:created_at) => integer(),
+          optional(:timestamps) => map(),
+          optional(:application_id) => Snowflake.t(),
+          optional(:details) => String.t() | nil,
+          optional(:state) => String.t() | nil,
+          optional(:emoji) => Emoji.t() | nil,
+          optional(:party) => map(),
+          optional(:assets) => map(),
+          optional(:secrets) => map(),
+          optional(:instance) => boolean(),
+          optional(:flags) => Presence.ActivityFlags.raw()
+        }
+
   Util.typesince("0.1.0")
 
   @type t :: %__MODULE__{
@@ -31,7 +55,7 @@ defmodule Crux.Structs.Presence do
           game: map() | nil,
           # guild_id: Snowflake.t() | nil,
           status: String.t(),
-          activities: [map()],
+          activities: [activity()],
           client_status: %{required(atom()) => atom()}
         }
 
@@ -66,7 +90,26 @@ defmodule Crux.Structs.Presence do
       data
       |> Util.atomify()
       |> Map.update!(:user, Util.map_to_id())
+      |> Map.update(:activities, [], fn activities ->
+        Enum.map(activities, &create_activity/1)
+      end)
 
     struct(__MODULE__, presence)
+  end
+
+  defp create_activity(%{application_id: application_id} = activity)
+       when not Snowflake.is_snowflake(application_id) do
+    activity
+    |> Map.update!(:application_id, &Snowflake.to_snowflake/1)
+    |> create_activity()
+  end
+
+  defp create_activity(%{emoji: emoji} = activity)
+       when not is_nil(emoji) do
+    Map.update!(activity, :emoji, &Structs.create(&1, Emoji))
+  end
+
+  defp create_activity(activity) do
+    activity
   end
 end

--- a/lib/structs/presence/activity_flags.ex
+++ b/lib/structs/presence/activity_flags.ex
@@ -1,0 +1,35 @@
+defmodule Crux.Structs.Presence.ActivityFlags do
+  @moduledoc """
+  Custom non discord API struct helping with the usage of presence activity flags.
+  """
+
+  alias Crux.Structs.Util
+  require Util
+  Util.modulesince("0.2.3")
+
+  use Bitwise
+
+  flags = %{
+    instance: 1 <<< 0,
+    join: 1 <<< 1,
+    spectate: 1 <<< 2,
+    join_request: 1 <<< 3,
+    sync: 1 <<< 4,
+    play: 1 <<< 5
+  }
+
+  use Crux.Structs.BitField, flags
+
+  @typedoc """
+  Union type of all valid presence activity flags.
+  """
+  Util.typesince("0.2.3")
+
+  @type name ::
+          :instance
+          | :join
+          | :spectate
+          | :join_request
+          | :sync
+          | :play
+end

--- a/lib/structs/presence/activity_flags.ex
+++ b/lib/structs/presence/activity_flags.ex
@@ -4,9 +4,6 @@ defmodule Crux.Structs.Presence.ActivityFlags do
   """
 
   alias Crux.Structs.Util
-  require Util
-  Util.modulesince("0.2.3")
-
   use Bitwise
 
   flags = %{
@@ -19,6 +16,10 @@ defmodule Crux.Structs.Presence.ActivityFlags do
   }
 
   use Crux.Structs.BitField, flags
+
+  require Util
+
+  Util.modulesince("0.2.3")
 
   @typedoc """
   Union type of all valid presence activity flags.

--- a/lib/structs/role.ex
+++ b/lib/structs/role.ex
@@ -6,7 +6,7 @@ defmodule Crux.Structs.Role do
   @behaviour Crux.Structs
 
   alias Crux.Structs
-  alias Crux.Structs.{Role, Snowflake, Util}
+  alias Crux.Structs.{Permissions, Role, Snowflake, Util}
   require Util
 
   Util.modulesince("0.1.0")
@@ -31,7 +31,7 @@ defmodule Crux.Structs.Role do
           color: integer(),
           hoist: boolean(),
           position: integer(),
-          permissions: integer(),
+          permissions: Permissions.raw(),
           managed: boolean(),
           mentionable: boolean(),
           guild_id: Snowflake.t()

--- a/lib/structs/user.ex
+++ b/lib/structs/user.ex
@@ -28,7 +28,7 @@ defmodule Crux.Structs.User do
           discriminator: String.t(),
           id: Snowflake.t(),
           username: String.t(),
-          public_flags: integer()
+          public_flags: User.Flags.raw()
         }
 
   @typedoc """

--- a/lib/structs/user/flags.ex
+++ b/lib/structs/user/flags.ex
@@ -1,0 +1,56 @@
+defmodule Crux.Structs.User.Flags do
+  @moduledoc """
+  Custom non discord API struct helping with the usage of user flags.
+
+  Discord is only providing a not documented subset of the available flags to bots.
+  """
+
+  alias Crux.Structs.Util
+  require Util
+  Util.modulesince("0.2.3")
+
+  use Bitwise
+
+  flags = %{
+    discord_employee: 1 <<< 0,
+    discord_partner: 1 <<< 1,
+    hypesquad_events: 1 <<< 2,
+    bughunter_level_1: 1 <<< 3,
+    # 4
+    # 5
+    house_bravery: 1 <<< 6,
+    house_brilliance: 1 <<< 7,
+    house_balance: 1 <<< 8,
+    early_supporter: 1 <<< 9,
+    team_user: 1 <<< 10,
+    # 11
+    system: 1 <<< 12,
+    # 13
+    bughunter_level_2: 1 <<< 14,
+    # 15
+    verified_bot: 1 <<< 16,
+    verified_developer: 1 <<< 17
+  }
+
+  use Crux.Structs.BitField, flags
+
+  @typedoc """
+  Union type of all valid user flags.
+  """
+  Util.typesince("0.2.3")
+
+  @type name ::
+          :discord_employee
+          | :discord_partner
+          | :hypesquad_events
+          | :bughunter_level_1
+          | :house_bravery
+          | :house_brilliance
+          | :house_balance
+          | :early_supporter
+          | :team_user
+          | :system
+          | :bughunter_level_2
+          | :verified_bot
+          | :verified_developer
+end

--- a/lib/structs/user/flags.ex
+++ b/lib/structs/user/flags.ex
@@ -6,9 +6,6 @@ defmodule Crux.Structs.User.Flags do
   """
 
   alias Crux.Structs.Util
-  require Util
-  Util.modulesince("0.2.3")
-
   use Bitwise
 
   flags = %{
@@ -33,6 +30,10 @@ defmodule Crux.Structs.User.Flags do
   }
 
   use Crux.Structs.BitField, flags
+
+  require Util
+
+  Util.modulesince("0.2.3")
 
   @typedoc """
   Union type of all valid user flags.

--- a/test/structs/permissions_test.exs
+++ b/test/structs/permissions_test.exs
@@ -10,7 +10,7 @@ defmodule Crux.Structs.PermissionsTest do
 
     assert is_list(names)
 
-    assert Enum.size(names) > 0
+    assert length(names) > 0
   end
 
   test "flags/0" do

--- a/test/structs/permissions_test.exs
+++ b/test/structs/permissions_test.exs
@@ -5,172 +5,276 @@ defmodule Crux.Structs.PermissionsTest do
 
   doctest Permissions
 
-  test "to_map" do
-    permissions = [:view_channel, :send_messages, :kick_members, :embed_links]
+  test "names/0" do
+    names = Permissions.names()
 
-    Permissions.to_map(permissions)
-    |> Enum.each(fn {name, value} ->
-      assert {name, name in permissions} === {name, value}
-    end)
+    assert is_list(names)
+
+    assert Enum.size(names) > 0
   end
 
-  test "to_map administrator does not override" do
-    explicit_count =
-      :administrator
-      |> Permissions.to_map()
-      |> Map.values()
-      |> Enum.count(& &1)
+  test "flags/0" do
+    flags = Permissions.flags()
 
-    assert explicit_count === 1
+    assert is_map(flags)
+
+    assert map_size(flags) > 0
   end
 
-  test "to_list" do
-    permissions = [:view_channel, :send_messages, :kick_members, :embed_links]
-
-    assert permissions === Permissions.to_list(permissions)
+  test "all/0" do
+    assert Permissions.all() > 0
   end
 
-  test "to_list administrator does not override" do
-    explicit_count =
-      :administrator
-      |> Permissions.to_list()
-      |> Enum.count()
+  describe "resolve/1" do
+    test "a single bitflag" do
+      assert 0x8 == Permissions.resolve(0x8)
+    end
 
-    assert explicit_count === 1
+    test "a single name" do
+      assert 0x8 == Permissions.resolve(:administrator)
+    end
+
+    test "a list of names" do
+      assert 0xC == Permissions.resolve([:administrator, :ban_members])
+    end
+
+    test "a list of names and bitflags" do
+      assert 0x10000C40 == Permissions.resolve([:manage_roles, 0x400, 0x800, :add_reactions])
+    end
+
+    test "an empty list" do
+      assert 0x0 == Permissions.resolve([])
+    end
   end
 
-  test "implicit/2 owner overrides" do
-    member = %Member{user: 218_348_062_828_003_328}
-    guild = %Guild{owner_id: 218_348_062_828_003_328}
-
-    %Permissions{bitfield: bitfield} = Permissions.implicit(member, guild)
-
-    assert bitfield === Permissions.all()
+  test "add/2" do
+    assert Permissions.new(0x28) == Permissions.add(:administrator, :manage_guild)
   end
 
-  test "implicit/2 administrator overrides" do
-    [member, guild, _] = test_data()
-
-    %Permissions{bitfield: bitfield} = Permissions.implicit(member, guild)
-
-    assert bitfield === Permissions.all()
+  test "remove/2" do
+    assert Permissions.new(0x8) == Permissions.remove([0x8, 0x10, 0x20], [0x10, 0x20])
   end
 
-  test "implicit/3 administrator override" do
-    [member, guild, channel] = test_data()
+  describe "has/2" do
+    test "administrator won't grant any other permissions" do
+      refute Permissions.has(0x8, Permissions.all())
+    end
 
-    %Permissions{bitfield: bitfield} = Permissions.implicit(member, guild, channel)
-
-    assert bitfield === Permissions.all()
-  end
-
-  test "implicit/3 administrator in overwrite does not override" do
-    [member, guild, channel] =
-      test_data(no_admin: true, allow: Permissions.resolve([:administrator]), deny: 0)
-
-    %Permissions{bitfield: bitfield} = Permissions.implicit(member, guild, channel)
-
-    # not equal to Permissions.all() !
-    assert bitfield ===
-             Permissions.resolve([
-               :administrator,
-               :view_channel,
+    test "resolving a list of names" do
+      assert Permissions.has([:send_messages, :view_channel, :read_message_history], [
                :send_messages,
-               :kick_members,
-               :ban_members,
-               :read_message_history
+               :view_channel
              ])
+    end
+
+    test "resolving different types" do
+      assert Permissions.has(:administrator, 0x8)
+      assert Permissions.has(0x8, :administrator)
+    end
   end
 
-  test "explicit/2 administrator nor owner does not override" do
-    [member, guild, _] = test_data()
-    guild = Map.put(guild, :owner, member.user)
+  describe "missing/2" do
+    test "basic usage" do
+      assert Permissions.new(0x4000) ==
+               Permissions.missing([:send_messages, :view_channel], [
+                 :send_messages,
+                 :view_channel,
+                 :embed_links
+               ])
+    end
 
-    %Permissions{bitfield: bitfield} = Permissions.explicit(member, guild)
+    test "administrator does not implicitly grant permissions" do
+      assert Permissions.new(0x800) == Permissions.missing([:administrator], [:send_messages])
+    end
 
-    assert bitfield ===
-             Permissions.resolve([
-               :administrator,
-               :view_channel,
-               :send_messages,
-               :kick_members,
-               :ban_members,
-               :read_message_history
-             ])
+    test "everything set returns empty bitfield" do
+      assert Permissions.new(0x0) ==
+               Permissions.missing([:kick_members, :ban_members, :view_audit_log], [
+                 :kick_members,
+                 :ban_members,
+                 :view_audit_log
+               ])
+    end
+
+    test "no permissions wanted" do
+      assert Permissions.new(0x0) == Permissions.missing([:send_messages, :view_channel], [])
+    end
   end
 
-  test "explicit/3 administrator nor owner does not override" do
-    [member, guild, channel] = test_data(allow: Permissions.resolve([:administrator]))
-    guild = Map.put(guild, :owner, member.user)
+  describe "to_map" do
+    test "no :administrator set" do
+      permissions = [:view_channel, :send_messages, :kick_members, :embed_links]
 
-    %Permissions{bitfield: bitfield} = Permissions.explicit(member, guild, channel)
+      Permissions.to_map(permissions)
+      |> Enum.each(fn {name, value} ->
+        assert {name, name in permissions} === {name, value}
+      end)
+    end
 
-    assert bitfield ===
-             Permissions.resolve([
-               :administrator,
-               :send_messages,
-               :kick_members,
-               :ban_members,
-               :read_message_history
-             ])
+    test ":administrator set, it does not override" do
+      explicit_count =
+        :administrator
+        |> Permissions.to_map()
+        |> Map.values()
+        |> Enum.count(& &1)
+
+      assert explicit_count === 1
+    end
   end
 
-  test "no roles does not raise" do
-    [member, guild, _] = test_data()
+  describe "to_list/1" do
+    test "no :administrator set" do
+      permissions = [:view_channel, :send_messages, :kick_members, :embed_links]
 
-    guild =
-      Map.update!(
-        guild,
-        :members,
-        fn members ->
-          Map.update!(members, 218_348_062_828_003_328, &Map.put(&1, :roles, MapSet.new()))
-        end
-      )
+      assert permissions === Permissions.to_list(permissions)
+    end
 
-    assert guild.members[218_348_062_828_003_328].roles |> MapSet.size() === 0
+    test ":administrator set, it does not override" do
+      explicit_count =
+        :administrator
+        |> Permissions.to_list()
+        |> Enum.count()
 
-    %Permissions{bitfield: bitfield} = Permissions.explicit(member, guild)
-
-    assert bitfield === Permissions.resolve([:view_channel, :send_messages])
+      assert explicit_count === 1
+    end
   end
 
-  defp test_data(options \\ []) do
-    member = %Member{user: 218_348_062_828_003_328}
+  describe "implicit/2,3" do
+    test "implicit/2 owner overrides" do
+      member = %Member{user: 218_348_062_828_003_328}
+      guild = %Guild{owner_id: 218_348_062_828_003_328}
 
-    guild = %Guild{
-      id: 243_175_181_885_898_762,
-      members: %{
-        218_348_062_828_003_328 => %Member{
-          roles: MapSet.new([251_158_405_832_638_465, 373_405_430_589_816_834])
-        }
-      },
-      roles: %{
-        # @everyone
-        243_175_181_885_898_762 => %Role{
-          permissions: Permissions.resolve([:view_channel, :send_messages])
+      %Permissions{bitfield: bitfield} = Permissions.implicit(member, guild)
+
+      assert bitfield === Permissions.all()
+    end
+
+    test "implicit/2 administrator overrides" do
+      [member, guild, _] = test_data()
+
+      %Permissions{bitfield: bitfield} = Permissions.implicit(member, guild)
+
+      assert bitfield === Permissions.all()
+    end
+
+    test "implicit/3 administrator override" do
+      [member, guild, channel] = test_data()
+
+      %Permissions{bitfield: bitfield} = Permissions.implicit(member, guild, channel)
+
+      assert bitfield === Permissions.all()
+    end
+
+    test "implicit/3 administrator in overwrite does not override" do
+      [member, guild, channel] =
+        test_data(no_admin: true, allow: Permissions.resolve([:administrator]), deny: 0)
+
+      %Permissions{bitfield: bitfield} = Permissions.implicit(member, guild, channel)
+
+      # not equal to Permissions.all() !
+      assert bitfield ===
+               Permissions.resolve([
+                 :administrator,
+                 :view_channel,
+                 :send_messages,
+                 :kick_members,
+                 :ban_members,
+                 :read_message_history
+               ])
+    end
+  end
+
+  describe "explicit/2,3" do
+    test "explicit/2 administrator nor owner does not override" do
+      [member, guild, _] = test_data()
+      guild = Map.put(guild, :owner, member.user)
+
+      %Permissions{bitfield: bitfield} = Permissions.explicit(member, guild)
+
+      assert bitfield ===
+               Permissions.resolve([
+                 :administrator,
+                 :view_channel,
+                 :send_messages,
+                 :kick_members,
+                 :ban_members,
+                 :read_message_history
+               ])
+    end
+
+    test "explicit/3 administrator nor owner does not override" do
+      [member, guild, channel] = test_data(allow: Permissions.resolve([:administrator]))
+      guild = Map.put(guild, :owner, member.user)
+
+      %Permissions{bitfield: bitfield} = Permissions.explicit(member, guild, channel)
+
+      assert bitfield ===
+               Permissions.resolve([
+                 :administrator,
+                 :send_messages,
+                 :kick_members,
+                 :ban_members,
+                 :read_message_history
+               ])
+    end
+
+    test "no roles does not raise" do
+      [member, guild, _] = test_data()
+
+      guild =
+        Map.update!(
+          guild,
+          :members,
+          fn members ->
+            Map.update!(members, 218_348_062_828_003_328, &Map.put(&1, :roles, MapSet.new()))
+          end
+        )
+
+      assert guild.members[218_348_062_828_003_328].roles |> MapSet.size() === 0
+
+      %Permissions{bitfield: bitfield} = Permissions.explicit(member, guild)
+
+      assert bitfield === Permissions.resolve([:view_channel, :send_messages])
+    end
+
+    defp test_data(options \\ []) do
+      member = %Member{user: 218_348_062_828_003_328}
+
+      guild = %Guild{
+        id: 243_175_181_885_898_762,
+        members: %{
+          218_348_062_828_003_328 => %Member{
+            roles: MapSet.new([251_158_405_832_638_465, 373_405_430_589_816_834])
+          }
         },
-        251_158_405_832_638_465 => %Role{
-          permissions: Permissions.resolve([:kick_members, :ban_members])
-        },
-        373_405_430_589_816_834 => %Role{
-          permissions:
-            Permissions.resolve([
-              if(options[:no_admin], do: 0, else: :administrator),
-              :read_message_history
-            ])
+        roles: %{
+          # @everyone
+          243_175_181_885_898_762 => %Role{
+            permissions: Permissions.resolve([:view_channel, :send_messages])
+          },
+          251_158_405_832_638_465 => %Role{
+            permissions: Permissions.resolve([:kick_members, :ban_members])
+          },
+          373_405_430_589_816_834 => %Role{
+            permissions:
+              Permissions.resolve([
+                if(options[:no_admin], do: 0, else: :administrator),
+                :read_message_history
+              ])
+          }
         }
       }
-    }
 
-    channel = %Channel{
-      permission_overwrites: %{
-        243_175_181_885_898_762 => %Overwrite{
-          allow: options[:allow] || 0,
-          deny: options[:deny] || Permissions.resolve([:view_channel])
+      channel = %Channel{
+        permission_overwrites: %{
+          243_175_181_885_898_762 => %Overwrite{
+            allow: options[:allow] || 0,
+            deny: options[:deny] || Permissions.resolve([:view_channel])
+          }
         }
       }
-    }
 
-    [member, guild, channel]
+      [member, guild, channel]
+    end
   end
 end

--- a/test/structs/presence_test.exs
+++ b/test/structs/presence_test.exs
@@ -2,21 +2,99 @@ defmodule Crux.Structs.PresenceTest do
   use ExUnit.Case, async: true
   doctest Crux.Structs.Presence
 
-  test "create" do
-    presence =
-      %{
-        "user" => %{
-          "id" => "218348062828003328"
-        },
-        "game" => nil,
-        "status" => "online"
-      }
-      |> Crux.Structs.create(Crux.Structs.Presence)
+  describe "create/1" do
+    test "simple presence" do
+      presence =
+        %{
+          "user" => %{
+            "id" => "218348062828003328"
+          },
+          "game" => nil,
+          "status" => "online"
+        }
+        |> Crux.Structs.create(Crux.Structs.Presence)
 
-    assert presence == %Crux.Structs.Presence{
-             user: 218_348_062_828_003_328,
-             game: nil,
-             status: "online"
-           }
+      assert presence == %Crux.Structs.Presence{
+               user: 218_348_062_828_003_328,
+               game: nil,
+               status: "online"
+             }
+    end
+
+    test "custom status in activities" do
+      presence =
+        %{
+          "user" => %{
+            "id" => "218348062828003328"
+          },
+          "game" => nil,
+          "status" => "online",
+          "activities" => [
+            %{
+              "type" => 4,
+              # What is "type" anyway?
+              "name" => "CUSTOM_STATUS",
+              "state" => "Some status",
+              "emoji" => %{
+                "id" => "340234098767560724",
+                "name" => "Missing",
+                "animated" => false
+              }
+            }
+          ]
+        }
+        |> Crux.Structs.create(Crux.Structs.Presence)
+
+      assert presence == %Crux.Structs.Presence{
+               user: 218_348_062_828_003_328,
+               game: nil,
+               activities: [
+                 %{
+                   type: 4,
+                   name: "CUSTOM_STATUS",
+                   state: "Some status",
+                   emoji: %Crux.Structs.Emoji{
+                     id: 340_234_098_767_560_724,
+                     name: "Missing",
+                     animated: false,
+                     roles: MapSet.new()
+                   }
+                 }
+               ],
+               status: "online"
+             }
+    end
+
+    test "activity from an application" do
+      presence =
+        %{
+          "user" => %{
+            "id" => "218348062828003328"
+          },
+          "game" => nil,
+          "status" => "online",
+          "activities" => [
+            %{
+              "type" => 1,
+              "name" => "foo",
+              "application_id" => "474807795183648809"
+            }
+          ]
+        }
+        |> Crux.Structs.create(Crux.Structs.Presence)
+
+      assert presence == %Crux.Structs.Presence{
+               user: 218_348_062_828_003_328,
+               game: nil,
+               activities: [
+                 %{
+                   type: 1,
+                   name: "foo",
+                   application_id: 474_807_795_183_648_809
+                 }
+               ],
+               status: "online"
+             }
+    end
   end
 end

--- a/test/structs/presence_test.exs
+++ b/test/structs/presence_test.exs
@@ -65,7 +65,7 @@ defmodule Crux.Structs.PresenceTest do
              }
     end
 
-    test "activity from an application" do
+    test "activity of an application" do
       presence =
         %{
           "user" => %{


### PR DESCRIPTION
This PR adds the `BitField` behaviour and its module providing a `__using__` macro implementing this behaviour.

This PR adds the following concrete bitfields:
- `User.Flags`
- `Guild.SystemChannelFlags`
- `Message.Flags`
- `Presence.ActivityFlags`